### PR TITLE
Added env vars to make lessons repo configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,13 @@ type SyringeConfig struct {
 	HealthCheckInterval int
 	TSDBExportInterval  int
 	TSDBEnabled         bool
-	IgnoreDisabled      bool // This ignores the "disabled" field in lesson definitions. Useful for showing lessons in any state when running in dev, etc. Will load lesson regardless.
+
+	LessonRepoRemote string
+	LessonRepoBranch string
+	LessonRepoDir    string
+
+	// SOON TO BE DEPRECATED IN FAVOR OF TIER
+	IgnoreDisabled bool // This ignores the "disabled" field in lesson definitions. Useful for showing lessons in any state when running in dev, etc. Will load lesson regardless.
 }
 
 func LoadConfigVars() (*SyringeConfig, error) {
@@ -65,6 +71,27 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.IgnoreDisabled = true
 	} else {
 		config.IgnoreDisabled = false
+	}
+
+	remote := os.Getenv("SYRINGE_LESSON_REPO_REMOTE")
+	if remote == "" {
+		config.LessonRepoRemote = "https://github.com/nre-learning/antidote.git"
+	} else {
+		config.LessonRepoRemote = remote
+	}
+
+	branch := os.Getenv("SYRINGE_LESSON_REPO_BRANCH")
+	if remote == "" {
+		config.LessonRepoBranch = "master"
+	} else {
+		config.LessonRepoBranch = branch
+	}
+
+	dir := os.Getenv("SYRINGE_LESSON_REPO_DIR")
+	if remote == "" {
+		config.LessonRepoDir = "/antidote"
+	} else {
+		config.LessonRepoDir = dir
 	}
 
 	return &config, nil

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -95,9 +95,9 @@ func (ls *LessonScheduler) createPod(dep *def.Endpoint, etype pb.Endpoint_Endpoi
 						"/usr/local/git/git-clone.sh",
 					},
 					Args: []string{
-						"https://github.com/nre-learning/antidote.git",
-						"master",
-						"/antidote",
+						ls.SyringeConfig.LessonRepoRemote,
+						ls.SyringeConfig.LessonRepoBranch,
+						ls.SyringeConfig.LessonRepoDir,
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -108,7 +108,7 @@ func (ls *LessonScheduler) createPod(dep *def.Endpoint, etype pb.Endpoint_Endpoi
 						{
 							Name:      "git-volume",
 							ReadOnly:  false,
-							MountPath: "/antidote",
+							MountPath: ls.SyringeConfig.LessonRepoDir,
 						},
 					},
 				},
@@ -128,7 +128,7 @@ func (ls *LessonScheduler) createPod(dep *def.Endpoint, etype pb.Endpoint_Endpoi
 						{
 							Name:      "git-volume",
 							ReadOnly:  false,
-							MountPath: "/antidote",
+							MountPath: ls.SyringeConfig.LessonRepoDir,
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Currently, the repository that Syringe clones into each Pod it creates is defined statically. It's useful, when developing new lessons, to be able to customize this.

This PR adds a few environment variables to make this possible.