### PR TITLE
Use ingresses for iframe resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Modified lessondefs api to output all lessons in one call - [#18](https://github.com/nre-learning/syringe/pull/18)
 - Make iframe resource image configurable - [#19](https://github.com/nre-learning/syringe/pull/19)
+- Use ingresses for all iframe resources - [#28](https://github.com/nre-learning/syringe/pull/28)
 
 ### Curriculum
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 type SyringeConfig struct {
 	LessonsDir          string
 	Tier                string
+	Domain              string
 	GRPCPort            int
 	HTTPPort            int
 	DeviceGCAge         int
@@ -36,6 +37,13 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		return nil, errors.New("SYRINGE_LESSONS is a required variable.")
 	} else {
 		config.LessonsDir = searchDir
+	}
+
+	domain := os.Getenv("SYRINGE_DOMAIN")
+	if domain == "" {
+		return nil, errors.New("SYRINGE_DOMAIN is a required variable.")
+	} else {
+		config.Domain = domain
 	}
 
 	/*

--- a/def/yaml.go
+++ b/def/yaml.go
@@ -12,18 +12,19 @@ import (
 )
 
 type LessonDefinition struct {
-	LessonName    string                 `json:"lessonName" yaml:"lessonName"`
-	LessonID      int32                  `json:"lessonID" yaml:"lessonID"`
-	Devices       []*Endpoint            `json:"devices" yaml:"devices"`
-	Utilities     []*Endpoint            `json:"utilities" yaml:"utilities"`
-	Blackboxes    []*Endpoint            `json:"blackboxes" yaml:"blackboxes"`
-	Connections   []*Connection          `json:"connections" yaml:"connections"`
-	TopologyType  string                 `json:"topologyType" yaml:"topologyType"`
-	Stages        map[int32]*LessonStage `json:"stages" yaml:"stages"`
-	Category      string                 `json:"category" yaml:"category"`
-	LessonDiagram string                 `json:"lessondiagram" yaml:"lessondiagram"`
-	LessonVideo   string                 `json:"lessonvideo" yaml:"lessonvideo"`
-	Tier          string                 `json:"tier" yaml:"tier"`
+	LessonName      string                 `json:"lessonName" yaml:"lessonName"`
+	LessonID        int32                  `json:"lessonID" yaml:"lessonID"`
+	IframeResources []*IframeResource      `json:"iframeresources" yaml:"iframeresources"`
+	Devices         []*Endpoint            `json:"devices" yaml:"devices"`
+	Utilities       []*Endpoint            `json:"utilities" yaml:"utilities"`
+	Blackboxes      []*Endpoint            `json:"blackboxes" yaml:"blackboxes"`
+	Connections     []*Connection          `json:"connections" yaml:"connections"`
+	TopologyType    string                 `json:"topologyType" yaml:"topologyType"`
+	Stages          map[int32]*LessonStage `json:"stages" yaml:"stages"`
+	Category        string                 `json:"category" yaml:"category"`
+	LessonDiagram   string                 `json:"lessondiagram" yaml:"lessondiagram"`
+	LessonVideo     string                 `json:"lessonvideo" yaml:"lessonvideo"`
+	Tier            string                 `json:"tier" yaml:"tier"`
 }
 
 type Endpoint struct {
@@ -35,13 +36,12 @@ type Endpoint struct {
 }
 
 type LessonStage struct {
-	LabGuide       string            `json:"labguide" yaml:"labguide"`
-	Configs        map[string]string `json:"configs" yaml:"configs"`
-	IframeResource IframeDetails     `json:"iframeresource" yaml:"iframeresource"`
-	Description    string            `json:"description" yaml:"description"`
+	LabGuide    string            `json:"labguide" yaml:"labguide"`
+	Configs     map[string]string `json:"configs" yaml:"configs"`
+	Description string            `json:"description" yaml:"description"`
 }
 
-type IframeDetails struct {
+type IframeResource struct {
 	Name     string `json:"name" yaml:"name"`
 	Image    string `json:"image" yaml:"image"`
 	Protocol string `json:"protocol" yaml:"protocol"`

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -20,15 +20,6 @@ func (ls *LessonScheduler) createIngress(svcBuddy *corev1.Service, ifr *def.Ifra
 		panic(err)
 	}
 
-	//TODO: Make this configurable
-	domain := "ptr.labs.networkreliability.engineering"
-	// var domain string
-	// if ls.SyringeConfig.Tier == "ptr" {
-	// 	domain = "ptr.labs.networkreliability.engineering"
-	// } else {
-	// 	domain = "labs.networkreliability.engineering"
-	// }
-
 	nsName := svcBuddy.ObjectMeta.Namespace
 
 	newIngress := v1beta1.Ingress{
@@ -54,13 +45,13 @@ func (ls *LessonScheduler) createIngress(svcBuddy *corev1.Service, ifr *def.Ifra
 		Spec: v1beta1.IngressSpec{
 			TLS: []v1beta1.IngressTLS{
 				{
-					Hosts:      []string{domain},
+					Hosts:      []string{ls.SyringeConfig.Domain},
 					SecretName: "tls-certificate",
 				},
 			},
 			Rules: []v1beta1.IngressRule{
 				{
-					Host: domain,
+					Host: ls.SyringeConfig.Domain,
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -1,0 +1,105 @@
+package scheduler
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	def "github.com/nre-learning/syringe/def"
+	corev1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	betav1client "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+)
+
+func (ls *LessonScheduler) createIngress(svcBuddy *corev1.Service, ifr *def.IframeResource) (*v1beta1.Ingress, error) {
+
+	betaclient, err := betav1client.NewForConfig(ls.KubeConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	//TODO: Make this configurable
+	domain := "ptr.labs.networkreliability.engineering"
+	// var domain string
+	// if ls.SyringeConfig.Tier == "ptr" {
+	// 	domain = "ptr.labs.networkreliability.engineering"
+	// } else {
+	// 	domain = "labs.networkreliability.engineering"
+	// }
+
+	nsName := svcBuddy.ObjectMeta.Namespace
+
+	newIngress := v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ifr.Name,
+			Namespace: nsName,
+			Labels: map[string]string{
+				"syringeManaged": "yes",
+				"endpointType":   svcBuddy.ObjectMeta.Labels["endpointType"],
+			},
+			Annotations: map[string]string{
+				"ingress.kubernetes.io/ingress.class":           "nginx",
+				"ingress.kubernetes.io/ssl-services":            ifr.Name,
+				"ingress.kubernetes.io/ssl-redirect":            "true",
+				"ingress.kubernetes.io/force-ssl-redirect":      "true",
+				"ingress.kubernetes.io/rewrite-target":          fmt.Sprintf("/%s-%s", nsName, ifr.Name),
+				"nginx.ingress.kubernetes.io/rewrite-target":    fmt.Sprintf("/%s-%s", nsName, ifr.Name),
+				"nginx.ingress.kubernetes.io/limit-connections": "10",
+				"nginx.ingress.kubernetes.io/limit-rps":         "5",
+			},
+		},
+
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts: []string{domain},
+
+					//TODO(mierdin): Prudent to do a check for this
+					SecretName: "tls-certificate",
+				},
+			},
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: domain,
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: ifr.URI,
+									Backend: v1beta1.IngressBackend{
+										ServiceName: ifr.Name,
+										ServicePort: intstr.FromInt(int(ifr.Port)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	result, err := betaclient.Ingresses(nsName).Create(&newIngress)
+	if err == nil {
+		log.WithFields(log.Fields{
+			"namespace": nsName,
+		}).Infof("Created ingress: %s", result.ObjectMeta.Name)
+
+	} else if apierrors.IsAlreadyExists(err) {
+		log.Warnf("Ingress %s already exists.", ifr.Name)
+
+		result, err := betaclient.Ingresses(nsName).Get(ifr.Name, metav1.GetOptions{})
+		if err != nil {
+			log.Errorf("Couldn't retrieve pod after failing to create a duplicate: %s", err)
+			return nil, err
+		}
+		return result, nil
+	} else {
+		log.Errorf("Problem creating ingress %s: %s", ifr.Name, err)
+		return nil, err
+	}
+
+	return result, nil
+
+}

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -168,6 +168,7 @@ func (ls *LessonScheduler) configureDevice(ep *pb.Endpoint, req *LessonScheduleR
 								fmt.Sprintf("--optional_args=port=%d", ep.Port),
 								ep.Host,
 								"configure",
+								// req.LessonDef.Stages[req.Stage].Configs[ep.Name],
 								fmt.Sprintf("/antidote/lessons/lesson-%d/stage%d/configs/%s.txt", req.LessonDef.LessonID, req.Stage, ep.Name),
 								"--strategy=merge",
 							},
@@ -229,53 +230,3 @@ func (ls *LessonScheduler) configureDevice(ep *pb.Endpoint, req *LessonScheduleR
 	}
 	return result, err
 }
-
-// ---
-// apiVersion: batch/v1
-// kind: Job
-// metadata:
-//   name: configure-lab0-vqfx1
-// spec:
-//   template:
-//     metadata:
-//       name: napalm
-//     spec:
-//       initContainers:
-//       - name: git-clone
-//         image: alpine/git # Any image with git will do
-//         command:
-//         - /usr/local/git/git-clone.sh
-//         args:
-//         - "https://github.com/nre-learning/antidote.git"
-//         - "master"
-//         - "/antidote"
-//         volumeMounts:
-//         - name: git-clone
-//           mountPath: /usr/local/git
-//         - name: git-volume
-//           mountPath: /antidote
-
-//       containers:
-//       - name: napalm
-//         image: antidotelabs/napalm
-//         command:
-//          - napalm
-//          - --user=root
-//          - --password=VR-netlab9
-//          - --vendor=junos
-//          - --optional_args=port=30021
-//          - vip.labs.networkreliability.engineering
-//          - configure
-//          - /antidote/platform/sharedlab/vqfx1.txt
-//          - --strategy=merge
-//         volumeMounts:
-//           - mountPath: /antidote
-//             name: git-volume
-//       volumes:
-//         - name: git-volume
-//           emptyDir: {}
-//         - name: git-clone
-//           configMap:
-//             name: git-clone
-//             defaultMode: 0755
-//       restartPolicy: Never

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -119,9 +119,9 @@ func (ls *LessonScheduler) createPod(dep *def.Endpoint, etype pb.Endpoint_Endpoi
 					Image: dep.Image,
 
 					// Omitting in order to keep things speedy. For debugging, uncomment this, and the image will be pulled every time.
-					// ImagePullPolicy: "Always",
+					ImagePullPolicy: "Always",
 
-					ImagePullPolicy: "IfNotPresent",
+					// ImagePullPolicy: "IfNotPresent",
 
 					Ports: []corev1.ContainerPort{}, // Will set below
 					VolumeMounts: []corev1.VolumeMount{
@@ -180,10 +180,12 @@ func (ls *LessonScheduler) createPod(dep *def.Endpoint, etype pb.Endpoint_Endpoi
 		// Add back in at the beginning, and append the rest.
 		dep.Ports = append([]int32{22}, newports...)
 
-	} else if etype.String() == "IFRAME" {
-		port := req.LessonDef.Stages[req.Stage].IframeResource.Port
-		pod.Spec.Containers[0].Ports = append(pod.Spec.Containers[0].Ports, corev1.ContainerPort{ContainerPort: port})
 	}
+
+	// else if etype.String() == "IFRAME" {
+	// 	port := req.LessonDef.Stages[req.Stage].IframeResource.Port
+	// 	pod.Spec.Containers[0].Ports = append(pod.Spec.Containers[0].Ports, corev1.ContainerPort{ContainerPort: port})
+	// }
 
 	// Add any remaining ports not specified by the user
 	for p := range dep.Ports {

--- a/scheduler/secrets.go
+++ b/scheduler/secrets.go
@@ -1,0 +1,49 @@
+package scheduler
+
+import (
+	log "github.com/Sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func (ls *LessonScheduler) syncSecret(nsName string) error {
+
+	coreclient, err := corev1client.NewForConfig(ls.KubeConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	prodCert, err := coreclient.Secrets("prod").Get("tls-certificate", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	//Copy secret into this namespace
+	prodCert.ObjectMeta.Namespace = nsName
+
+	newCert := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      prodCert.ObjectMeta.Name,
+			Namespace: prodCert.ObjectMeta.Namespace,
+		},
+		Data:       prodCert.Data,
+		StringData: prodCert.StringData,
+		Type:       prodCert.Type,
+	}
+
+	result, err := coreclient.Secrets(nsName).Create(&newCert)
+	if err == nil {
+		log.WithFields(log.Fields{
+			"namespace": nsName,
+		}).Infof("Created secret: %s", result.ObjectMeta.Name)
+	} else if apierrors.IsAlreadyExists(err) {
+		log.Warnf("Secret %s already exists.", newCert.ObjectMeta.Name)
+		return nil
+	} else {
+		log.Errorf("Problem creating secret %s: %s", newCert.ObjectMeta.Name, err)
+		return err
+	}
+	return nil
+}

--- a/scheduler/services.go
+++ b/scheduler/services.go
@@ -28,13 +28,6 @@ func (ls *LessonScheduler) createService(pod *corev1.Pod, req *LessonScheduleReq
 
 	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonID, req.Session)
 
-	serviceTypeMap := map[string]corev1.ServiceType{
-		"UTILITY":  corev1.ServiceTypeClusterIP,
-		"BLACKBOX": corev1.ServiceTypeClusterIP,
-		"DEVICE":   corev1.ServiceTypeClusterIP,
-		"IFRAME":   corev1.ServiceTypeNodePort,
-	}
-
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -56,7 +49,7 @@ func (ls *LessonScheduler) createService(pod *corev1.Pod, req *LessonScheduleReq
 			},
 			Ports: []corev1.ServicePort{}, // will fill out below
 
-			Type: serviceTypeMap[pod.ObjectMeta.Labels["endpointType"]],
+			Type: corev1.ServiceTypeClusterIP,
 		},
 	}
 


### PR DESCRIPTION
Currently, iframe resources are a bit neglected. I moved to make them more generic, instead of specifically using jupyter notebooks, but this is still not ideal. In addition to the issue brought up in https://github.com/nre-learning/syringe/issues/27, the current method of exposing these via NodePort, in spite of the fact that EVERYTHING ELSE goes through the nginx ingress controller, is a bit silly, and the DNS based load balancing wasn't ever fully automated.

This PR solves both problems by having Syringe create Ingress objects for each iframe resource, so that the iframe within the antidote-web page is pointing to the exact same domain, using the same certs - just a different path, managed by the nginx controller.

## TODOs

- [x] Make domain configurable (see TODO in ingresses.go)
- [x] changelog

Closes https://github.com/nre-learning/syringe/issues/27