### PR TITLE
Finally get things working with iframe resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## In development
 
 - Consolidate lesson definition logic, and provide local validation tool (syrctl) [#30](https://github.com/nre-learning/syringe/pull/30)
-
+- Redesign and fix the way iframe resources are created and presented to the API[#32](https://github.com/nre-learning/syringe/pull/32)
 
 ## 0.1.3 - November 15, 2018
 

--- a/api/exp/definitions/lessondef.proto
+++ b/api/exp/definitions/lessondef.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package syringe.api.exp;
 
-// import "validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "validate/validate.proto";
@@ -57,8 +56,8 @@ message LessonDefFilter {
 
 message LessonStage {
   int32 Id = 1 [(validate.rules).int32.gt = 0];
-  string Description = 2;
-  string LabGuide = 3;
+  string Description = 2 [(validate.rules).string.min_len = 1];
+  string LabGuide = 3 [(validate.rules).string.min_len = 1];
 }
 
 message Utility {
@@ -86,11 +85,10 @@ message Device {
 }
 
 message IframeResource {
-  string Name = 1 [(validate.rules).string.min_len = 1];
-  string Image = 2 [(validate.rules).string.min_len = 1];
-  string Protocol = 3 [(validate.rules).string.min_len = 1];
-  string Path = 4 [(validate.rules).string.min_len = 1];
-  int32 Port = 5 [(validate.rules).int32.gt = 0];
+  string Ref = 1 [(validate.rules).string.min_len = 1];
+  string Protocol = 2 [(validate.rules).string.min_len = 1];
+  string Path = 3 [(validate.rules).string.min_len = 1];
+  int32 Port = 4 [(validate.rules).int32.gt = 0];
 }
 
 message Connection {

--- a/api/exp/definitions/lessondef.swagger.json
+++ b/api/exp/definitions/lessondef.swagger.json
@@ -124,10 +124,7 @@
     "expIframeResource": {
       "type": "object",
       "properties": {
-        "Name": {
-          "type": "string"
-        },
-        "Image": {
+        "Ref": {
           "type": "string"
         },
         "Protocol": {

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -84,18 +84,11 @@ message LiveEndpoint {
   string Host = 3;
   int32 Port  = 4;
 
-  IFDetails IframeDetails = 5;
+  string IframePath = 5;
 
   string Sshuser = 6;
   string Sshpassword = 7;
 
-}
-
-message IFDetails {
-    string name = 1;
-    string Protocol = 2;
-    string URI = 3;
-    int32 Port = 4;
 }
 
 message LessonParams {

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -117,24 +117,6 @@
     "expHealthCheckMessage": {
       "type": "object"
     },
-    "expIFDetails": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "Protocol": {
-          "type": "string"
-        },
-        "URI": {
-          "type": "string"
-        },
-        "Port": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
     "expLessonParams": {
       "type": "object",
       "properties": {
@@ -187,8 +169,8 @@
           "type": "integer",
           "format": "int32"
         },
-        "IframeDetails": {
-          "$ref": "#/definitions/expIFDetails"
+        "IframePath": {
+          "type": "string"
         },
         "Sshuser": {
           "type": "string"

--- a/api/exp/lessondefs.go
+++ b/api/exp/lessondefs.go
@@ -138,12 +138,31 @@ FILES:
 			}
 		}
 
+		if len(lessonDef.IframeResources) > 0 {
+			for i := range lessonDef.IframeResources {
+				ifr := lessonDef.IframeResources[i]
+				if !entityInLabDef(ifr.Ref, &lessonDef) {
+					log.Errorf("Failed to import %s: %s", file, errors.New(fmt.Sprintf("Iframe resource refers to nonexistent entity %s", ifr.Ref)))
+					continue FILES
+				}
+			}
+		}
+
 		// TODO(mierdin): Make sure lesson ID, lesson name, stage ID and stage name are unique. If you try to read a value in, make sure it doesn't exist. If it does, error out
+
+		// TODO(mierdin): Need to validate that each name is unique across blackboxes, utilities, and devices.
 
 		// TODO(mierdin): Need to run checks to see that files are located where they need to be. Things like
 		// configs, and lesson guides
 
-		log.Infof("Successfully imported lesson %d: %s", lessonDef.LessonId, lessonDef.LessonName)
+		log.Infof("Successfully imported lesson %d: %s --- BLACKBOX: %d, IFR: %d, UTILITY: %d, DEVICE: %d, CONNECTIONS: %d", lessonDef.LessonId, lessonDef.LessonName,
+			len(lessonDef.Blackboxes),
+			len(lessonDef.IframeResources),
+			len(lessonDef.Utilities),
+			len(lessonDef.Devices),
+			len(lessonDef.Connections),
+		)
+
 		retLds[lessonDef.LessonId] = &lessonDef
 	}
 

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -127,10 +127,7 @@ Lessondef = `{
     "expIframeResource": {
       "type": "object",
       "properties": {
-        "Name": {
-          "type": "string"
-        },
-        "Image": {
+        "Ref": {
           "type": "string"
         },
         "Protocol": {

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -385,24 +385,6 @@ Livelesson = `{
     "expHealthCheckMessage": {
       "type": "object"
     },
-    "expIFDetails": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "Protocol": {
-          "type": "string"
-        },
-        "URI": {
-          "type": "string"
-        },
-        "Port": {
-          "type": "integer",
-          "format": "int32"
-        }
-      }
-    },
     "expLessonParams": {
       "type": "object",
       "properties": {
@@ -455,8 +437,8 @@ Livelesson = `{
           "type": "integer",
           "format": "int32"
         },
-        "IframeDetails": {
-          "$ref": "#/definitions/expIFDetails"
+        "IframePath": {
+          "type": "string"
         },
         "Sshuser": {
           "type": "string"

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -27,14 +27,16 @@ func (ls *LessonScheduler) createIngress(nsName string, ifr *pb.IframeResource) 
 				"syringeManaged": "yes",
 			},
 			Annotations: map[string]string{
-				"ingress.kubernetes.io/ingress.class":           "nginx",
-				"ingress.kubernetes.io/ssl-services":            ifr.Ref,
-				"ingress.kubernetes.io/ssl-redirect":            "true",
-				"ingress.kubernetes.io/force-ssl-redirect":      "true",
-				"ingress.kubernetes.io/rewrite-target":          "/",
-				"nginx.ingress.kubernetes.io/rewrite-target":    "/",
+				"ingress.kubernetes.io/ingress.class":      "nginx",
+				"ingress.kubernetes.io/ssl-services":       ifr.Ref,
+				"ingress.kubernetes.io/ssl-redirect":       "true",
+				"ingress.kubernetes.io/force-ssl-redirect": "true",
+				// "ingress.kubernetes.io/rewrite-target":          "/",
+				// "nginx.ingress.kubernetes.io/rewrite-target":    "/",
 				"nginx.ingress.kubernetes.io/limit-connections": "10",
 				"nginx.ingress.kubernetes.io/limit-rps":         "5",
+				"nginx.ingress.kubernetes.io/add-base-url":      "true",
+				"nginx.ingress.kubernetes.io/app-root":          "/13-jjtigg867ghr3gye-ns-jupyter/",
 			},
 		},
 
@@ -48,6 +50,8 @@ func (ls *LessonScheduler) createIngress(nsName string, ifr *pb.IframeResource) 
 			Rules: []v1beta1.IngressRule{
 				{
 					Host: ls.SyringeConfig.Domain,
+
+					// TODO(mierdin): need to build this based on incoming protocol from syringefile. Might need to be HTTPS
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -5,7 +5,6 @@ import (
 
 	pb "github.com/nre-learning/syringe/api/exp/generated"
 	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,30 +12,27 @@ import (
 	betav1client "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 )
 
-func (ls *LessonScheduler) createIngress(svcBuddy *corev1.Service, ifr *pb.IframeResource) (*v1beta1.Ingress, error) {
+func (ls *LessonScheduler) createIngress(nsName string, ifr *pb.IframeResource) (*v1beta1.Ingress, error) {
 
 	betaclient, err := betav1client.NewForConfig(ls.KubeConfig)
 	if err != nil {
 		panic(err)
 	}
 
-	nsName := svcBuddy.ObjectMeta.Namespace
-
 	newIngress := v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ifr.Name,
+			Name:      ifr.Ref,
 			Namespace: nsName,
 			Labels: map[string]string{
 				"syringeManaged": "yes",
-				"endpointType":   svcBuddy.ObjectMeta.Labels["endpointType"],
 			},
 			Annotations: map[string]string{
 				"ingress.kubernetes.io/ingress.class":           "nginx",
-				"ingress.kubernetes.io/ssl-services":            ifr.Name,
+				"ingress.kubernetes.io/ssl-services":            ifr.Ref,
 				"ingress.kubernetes.io/ssl-redirect":            "true",
 				"ingress.kubernetes.io/force-ssl-redirect":      "true",
-				"ingress.kubernetes.io/rewrite-target":          ifr.Path,
-				"nginx.ingress.kubernetes.io/rewrite-target":    ifr.Path,
+				"ingress.kubernetes.io/rewrite-target":          "/",
+				"nginx.ingress.kubernetes.io/rewrite-target":    "/",
 				"nginx.ingress.kubernetes.io/limit-connections": "10",
 				"nginx.ingress.kubernetes.io/limit-rps":         "5",
 			},
@@ -56,9 +52,9 @@ func (ls *LessonScheduler) createIngress(svcBuddy *corev1.Service, ifr *pb.Ifram
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{
 								{
-									Path: fmt.Sprintf("/%s-%s", nsName, ifr.Name),
+									Path: fmt.Sprintf("/%s-%s", nsName, ifr.Ref),
 									Backend: v1beta1.IngressBackend{
-										ServiceName: ifr.Name,
+										ServiceName: ifr.Ref,
 										ServicePort: intstr.FromInt(int(ifr.Port)),
 									},
 								},
@@ -76,16 +72,16 @@ func (ls *LessonScheduler) createIngress(svcBuddy *corev1.Service, ifr *pb.Ifram
 		}).Infof("Created ingress: %s", result.ObjectMeta.Name)
 
 	} else if apierrors.IsAlreadyExists(err) {
-		log.Warnf("Ingress %s already exists.", ifr.Name)
+		log.Warnf("Ingress %s already exists.", ifr.Ref)
 
-		result, err := betaclient.Ingresses(nsName).Get(ifr.Name, metav1.GetOptions{})
+		result, err := betaclient.Ingresses(nsName).Get(ifr.Ref, metav1.GetOptions{})
 		if err != nil {
 			log.Errorf("Couldn't retrieve ingress after failing to create a duplicate: %s", err)
 			return nil, err
 		}
 		return result, nil
 	} else {
-		log.Errorf("Problem creating ingress %s: %s", ifr.Name, err)
+		log.Errorf("Problem creating ingress %s: %s", ifr.Ref, err)
 		return nil, err
 	}
 

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -122,6 +122,12 @@ func (ls *LessonScheduler) createPod(ep Endpoint, etype pb.LiveEndpoint_Endpoint
 
 					// ImagePullPolicy: "IfNotPresent",
 
+					Env: []corev1.EnvVar{
+
+						// Passing in full ref as an env var in case the pod needs to configure a base URL for ingress purposes.
+						{Name: "SYRINGE_FULL_REF", Value: fmt.Sprintf("%s-%s", nsName, ep.GetName())},
+					},
+
 					Ports: []corev1.ContainerPort{}, // Will set below
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -552,12 +552,17 @@ func (kl *KubeLab) ToLiveLesson() *pb.LiveLesson {
 			// ApiPort
 		}
 
-		// The configuration is in the ingress, so we just need to pass the name to the web side and it can
-		// figure out the path itself.
-		if endpoint.Type == pb.LiveEndpoint_IFRAME {
-			endpoint.IframeDetails = &pb.IFDetails{
-				Name: endpoint.Name,
-			}
+		ret.LiveEndpoints = append(ret.LiveEndpoints, endpoint)
+	}
+
+	for i := range kl.CreateRequest.LessonDef.IframeResources {
+
+		ifr := kl.CreateRequest.LessonDef.IframeResources[i]
+
+		endpoint := &pb.LiveEndpoint{
+			Name:       ifr.Ref,
+			Type:       pb.LiveEndpoint_IFRAME,
+			IframePath: ifr.Path,
 		}
 
 		ret.LiveEndpoints = append(ret.LiveEndpoints, endpoint)
@@ -637,8 +642,10 @@ func isReachable(ll *pb.LiveLesson) bool {
 
 			if ep.GetType() == pb.LiveEndpoint_DEVICE || ep.GetType() == pb.LiveEndpoint_UTILITY {
 				testResult = sshTest(ep)
-			} else if ep.GetType() == pb.LiveEndpoint_IFRAME || ep.GetType() == pb.LiveEndpoint_BLACKBOX {
+			} else if ep.GetType() == pb.LiveEndpoint_BLACKBOX {
 				testResult = connectTest(ep)
+			} else {
+				testResult = true
 			}
 			mapMutex.Lock()
 			defer mapMutex.Unlock()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -453,29 +453,11 @@ func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, 
 
 		ifr := req.LessonDef.IframeResources[d]
 
-		// TODO(mierdin): Defining this as a blackbox to get it into the createPod function is a little wonky.
-		// You might have to modify the endpoint interface to include iframe resources as a first class citizen
-		iframePod, _ := ls.createPod(
-			&pb.Blackbox{
-				Name:  ifr.Name,
-				Image: ifr.Image,
-				Ports: []int32{ifr.Port},
-			},
-			pb.LiveEndpoint_IFRAME,
-			[]string{},
-			req,
-		)
-		kl.Pods[iframePod.ObjectMeta.Name] = iframePod
-
-		// Create service for this pod
-		iframeSvc, _ := ls.createService(
-			iframePod,
-			req,
-		)
-		kl.Services[iframeSvc.ObjectMeta.Name] = iframeSvc
+		// Iframe resources don't create pods/services on their own. You must define a blackbox/utility/device endpoint
+		// and then refer to that in the iframeresource definition. We're just creating an ingress here to access that endpoint.
 
 		iframeIngress, _ := ls.createIngress(
-			iframeSvc,
+			ns.ObjectMeta.Name,
 			ifr,
 		)
 		kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress


### PR DESCRIPTION
Re-doing the iframe design a bit. Now, Iframe resources won't create pods or services, only ingresses.

This means you have to create an actual endpoint (bb, device, utility) to actually run the thing you're opening an iframe to, but the plus side of this is that you can use the same endpoint to call an API or something on the back-end while presenting the same endpoint as an iframe.

This opens up many more questions wrt how presentation layer is defined in Syringe. It might be better to rethink how these endpoints are declared in a future PR.