### PR TITLE
Serve lab guide directly from the lesson definition API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In development
 
 - Simplified authentication by using consistent credentials, statically [#40](https://github.com/nre-learning/syringe/pull/40)
+- Serve lab guide directly from lesson definition API [#41](https://github.com/nre-learning/syringe/pull/41)
 
 ## 0.1.4 - January 08, 2019
 

--- a/api/exp/definitions/lessondef.proto
+++ b/api/exp/definitions/lessondef.proto
@@ -56,7 +56,7 @@ message LessonDefFilter {
 message LessonStage {
   int32 Id = 1 [(validate.rules).int32.gt = 0];
   string Description = 2 [(validate.rules).string.min_len = 1];
-  string LabGuide = 3 [(validate.rules).string.min_len = 1];
+  string LabGuide = 3;
 }
 
 message Utility {

--- a/api/exp/lessondefs.go
+++ b/api/exp/lessondefs.go
@@ -155,6 +155,18 @@ FILES:
 		// TODO(mierdin): Need to run checks to see that files are located where they need to be. Things like
 		// configs, and lesson guides
 
+		// Iterate over stages, and retrieve lesson guide content
+		for l := range lessonDef.Stages {
+			s := lessonDef.Stages[l]
+			fileName := fmt.Sprintf("%s/stage%d/guide.md", filepath.Dir(file), s.Id)
+			contents, err := ioutil.ReadFile(fileName)
+			if err != nil {
+				log.Errorf("Encountered problem reading lesson guide: %s", err)
+				continue FILES
+			}
+			lessonDef.Stages[l].LabGuide = string(contents)
+		}
+
 		log.Infof("Successfully imported lesson %d: %s --- BLACKBOX: %d, IFR: %d, UTILITY: %d, DEVICE: %d, CONNECTIONS: %d", lessonDef.LessonId, lessonDef.LessonName,
 			len(lessonDef.Blackboxes),
 			len(lessonDef.IframeResources),


### PR DESCRIPTION
This will simplify lesson definitions (no need to point to an external URL) and it will also reduce the effort during releases (no URL to update the tag/branch for)

Closes https://github.com/nre-learning/syringe/issues/22
