### PR TITLE
Simplify and improve safety of in-memory state model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Simplified authentication by using consistent credentials, statically [#40](https://github.com/nre-learning/syringe/pull/40)
 - Serve lab guide directly from lesson definition API [#41](https://github.com/nre-learning/syringe/pull/41)
+- Simplify and improve safety of in-memory state model [#42](https://github.com/nre-learning/syringe/pull/42)
 
 ## 0.1.4 - January 08, 2019
 

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -40,8 +40,6 @@ message SyringeState {
   // Map that contains a mapping of UUIDs to LiveLesson messages
   map<string, LiveLesson> Livelessons = 1;
 
-  // Map that contains a mapping of session IDs (19-abcdef) to LiveLesson UUID maps
-  map<string, string> Sessions = 2;
 }
 
 // A provisioned lab without the scheduler details. The server will translate from an underlying type
@@ -54,10 +52,9 @@ message LiveLesson {
   string LabGuide = 5;
   bool Ready = 6;
   google.protobuf.Timestamp createdTime = 7;
-  string sessionId = 8;
-  string LessonDiagram = 9;
-  string LessonVideo = 10;
-  bool Error = 11;
+  string LessonDiagram = 8;
+  string LessonVideo = 9;
+  bool Error = 10;
 }
 
 message LiveEndpoint {

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -29,25 +29,19 @@ service LiveLessonsService {
   }
 
   // Retrieve all livelessons
-  rpc ListLiveLessons(google.protobuf.Empty) returns (LiveLessonMap) {
-    option (google.api.http) = {
-      get: "/exp/livelessonall"
-    };
-  }
+  // SENSITIVE - do not expose via REST
+  rpc GetSyringeState(google.protobuf.Empty) returns (SyringeState) {}
 }
 
 message HealthCheckMessage {}
 
-message UUIDtoLiveLessonMap {
+message SyringeState {
+
+  // Map that contains a mapping of UUIDs to LiveLesson messages
   map<string, LiveLesson> Livelessons = 1;
-}
 
-message LessontoUUIDMap {
-  map<int32, UUIDtoLiveLessonMap> Uuids = 1;
-}
-
-message LiveLessonMap {
-  map<string, LessontoUUIDMap> Sessions = 1;
+  // Map that contains a mapping of session IDs (19-abcdef) to LiveLesson UUID maps
+  map<string, string> Sessions = 2;
 }
 
 // A provisioned lab without the scheduler details. The server will translate from an underlying type

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -177,9 +177,6 @@
           "type": "string",
           "format": "date-time"
         },
-        "sessionId": {
-          "type": "string"
-        },
         "LessonDiagram": {
           "type": "string"
         },
@@ -202,13 +199,6 @@
             "$ref": "#/definitions/expLiveLesson"
           },
           "title": "Map that contains a mapping of UUIDs to LiveLesson messages"
-        },
-        "Sessions": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Map that contains a mapping of session IDs (19-abcdef) to LiveLesson UUID maps"
         }
       }
     }

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -82,23 +82,6 @@
           "LiveLessonsService"
         ]
       }
-    },
-    "/exp/livelessonall": {
-      "get": {
-        "summary": "Retrieve all livelessons",
-        "operationId": "ListLiveLessons",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/expLiveLessonMap"
-            }
-          }
-        },
-        "tags": [
-          "LiveLessonsService"
-        ]
-      }
     }
   },
   "definitions": {
@@ -138,17 +121,6 @@
       "properties": {
         "id": {
           "type": "string"
-        }
-      }
-    },
-    "expLessontoUUIDMap": {
-      "type": "object",
-      "properties": {
-        "Uuids": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/expUUIDtoLiveLessonMap"
-          }
         }
       }
     },
@@ -221,25 +193,22 @@
       },
       "description": "A provisioned lab without the scheduler details. The server will translate from an underlying type\n(i.e. KubeLab) into this, so only the abstract, relevant details are presented."
     },
-    "expLiveLessonMap": {
-      "type": "object",
-      "properties": {
-        "Sessions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/expLessontoUUIDMap"
-          }
-        }
-      }
-    },
-    "expUUIDtoLiveLessonMap": {
+    "expSyringeState": {
       "type": "object",
       "properties": {
         "Livelessons": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/expLiveLesson"
-          }
+          },
+          "title": "Map that contains a mapping of UUIDs to LiveLesson messages"
+        },
+        "Sessions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Map that contains a mapping of session IDs (19-abcdef) to LiveLesson UUID maps"
         }
       }
     }

--- a/api/exp/influxdb.go
+++ b/api/exp/influxdb.go
@@ -220,7 +220,7 @@ func (s *server) getCountAndDuration(lessonId int32) (int64, int64) {
 	count := 0
 
 	durations := []int64{}
-	for _, liveLesson := range s.liveLessons {
+	for _, liveLesson := range s.liveLessonState {
 		if liveLesson.LessonId != lessonId {
 			continue
 		}

--- a/api/exp/influxdb.go
+++ b/api/exp/influxdb.go
@@ -39,7 +39,7 @@ func (s *server) recordProvisioningTime(timeSecs int, res *scheduler.LessonSched
 		Precision: "s",
 	})
 	if err != nil {
-		log.Error("Couldn't connect to Influxdb: ", err)
+		log.Error("Unable to create metrics batch point: ", err)
 		return err
 	}
 
@@ -67,11 +67,9 @@ func (s *server) recordProvisioningTime(timeSecs int, res *scheduler.LessonSched
 	// Write the batch
 	err = c.Write(bp)
 	if err != nil {
-		log.Error("Error writing InfluxDB Batch Points: ", err)
+		log.Warn("Unable to push provisioning time to Influx: ", err)
 		return err
 	}
-
-	log.Debugf("Wrote provisioning time to influxdb: %v", bp)
 
 	return nil
 }
@@ -99,7 +97,7 @@ func (s *server) recordRequestTSDB(req *scheduler.LessonScheduleRequest) error {
 		Precision: "s",
 	})
 	if err != nil {
-		log.Error("Couldn't connect to Influxdb: ", err)
+		log.Error("Unable to create metrics batch point: ", err)
 		return err
 	}
 
@@ -134,11 +132,9 @@ func (s *server) recordRequestTSDB(req *scheduler.LessonScheduleRequest) error {
 	// Write the batch
 	err = c.Write(bp)
 	if err != nil {
-		log.Error("Error writing InfluxDB Batch Points: ", err)
+		log.Warn("Unable to push request metrics to Influx: ", err)
 		return err
 	}
-
-	log.Debugf("Wrote request data to influxdb: %v", bp)
 
 	return nil
 }
@@ -171,7 +167,7 @@ func (s *server) startTSDBExport() error {
 			Precision: "s",
 		})
 		if err != nil {
-			log.Error("Couldn't connect to Influxdb: ", err)
+			log.Error("Unable to create metrics batch point: ", err)
 			continue
 		}
 
@@ -205,11 +201,9 @@ func (s *server) startTSDBExport() error {
 		// Write the batch
 		err = c.Write(bp)
 		if err != nil {
-			log.Error("Error writing InfluxDB Batch Points: ", err)
+			log.Warn("Unable to push periodic metrics to Influx: ", err)
 			continue
 		}
-
-		log.Debugf("Wrote session data to influxdb: %v", bp)
 	}
 
 	return nil

--- a/api/exp/influxdb.go
+++ b/api/exp/influxdb.go
@@ -107,13 +107,13 @@ func (s *server) recordRequestTSDB(req *scheduler.LessonScheduleRequest) error {
 	tags := map[string]string{
 		"lessonId":   strconv.Itoa(int(req.LessonDef.LessonId)),
 		"lessonName": req.LessonDef.LessonName,
-		"sessionId":  req.Session,
+		"uuid":       req.Uuid,
 		"operation":  string(req.Operation),
 	}
 
 	fields := map[string]interface{}{
 		"lessonId":     strconv.Itoa(int(req.LessonDef.LessonId)),
-		"sessionId":    req.Session,
+		"uuid":         req.Uuid,
 		"operation":    req.Operation,
 		"lessonName":   req.LessonDef.LessonName,
 		"lessonIDName": fmt.Sprintf("%d - %s", req.LessonDef.LessonId, req.LessonDef.LessonName),

--- a/api/exp/lessondefs.go
+++ b/api/exp/lessondefs.go
@@ -46,8 +46,6 @@ func (s *server) GetLessonDef(ctx context.Context, lid *pb.LessonID) (*pb.Lesson
 
 	lessonDef := s.scheduler.LessonDefs[lid.Id]
 
-	log.Debugf("Received request for lesson definition: %v", lessonDef)
-
 	return lessonDef, nil
 }
 

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -34,7 +34,7 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 		return nil, errors.New(msg)
 	}
 
-	lessonUuid := fmt.Sprintf("%s-%s", lp.LessonId, lp.SessionId)
+	lessonUuid := fmt.Sprintf("%d-%s", lp.LessonId, lp.SessionId)
 
 	// Identify lesson definition - return error if doesn't exist by ID
 	if _, ok := s.scheduler.LessonDefs[lp.LessonId]; !ok {
@@ -67,7 +67,6 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 				Operation: scheduler.OperationType_MODIFY,
 				Stage:     lp.LessonStage,
 				Uuid:      lessonUuid,
-				Session:   lp.SessionId,
 			}
 
 			s.scheduler.Requests <- req
@@ -81,8 +80,7 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 				LessonDef: s.scheduler.LessonDefs[lp.LessonId],
 				Operation: scheduler.OperationType_BOOP,
 				Stage:     0,
-				Uuid:      "",
-				Session:   lp.SessionId,
+				Uuid:      lessonUuid,
 			}
 
 			s.scheduler.Requests <- req
@@ -100,7 +98,6 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 		Stage:     lp.LessonStage,
 		Uuid:      lessonUuid,
 		Created:   time.Now(),
-		Session:   lp.SessionId,
 	}
 	s.scheduler.Requests <- req
 

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -33,6 +34,8 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 		return nil, errors.New(msg)
 	}
 
+	lessonUuid := fmt.Sprintf("%s-%s", lp.LessonId, lp.SessionId)
+
 	// Identify lesson definition - return error if doesn't exist by ID
 	if _, ok := s.scheduler.LessonDefs[lp.LessonId]; !ok {
 		log.Errorf("Couldn't find lesson ID %d", lp.LessonId)
@@ -51,93 +54,51 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 
 	// Check to see if it already exists in memory. If it does, don't send provision request.
 	// Just look it up and send UUID
-	if _, ok := s.sessions[lp.SessionId]; ok {
-		if lessonUuid, ok := s.sessions[lp.SessionId][lp.LessonId]; ok {
+	if s.LiveLessonExists(lessonUuid) {
 
-			if s.liveLessons[lessonUuid].LessonStage != lp.LessonStage {
+		if s.liveLessonState[lessonUuid].LessonStage != lp.LessonStage {
 
-				// 10.32.0.16 - - [28/Sep/2018:23:21:17 +0000] "POST /exp/livelesson HTTP/1.1" 408 66
-				// panic: runtime error: invalid memory address or nil pointer dereference
-				// [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xf4f88a]
-				// goroutine 342 [running]:
-				// github.com/nre-learning/syringe/api/exp.(*server).RequestLiveLesson(0xc4201d0020, 0x1370700, 0xc4204563f0, 0xc4204d3100, 0xc4201d0020, 0xc420456330, 0x1102de0)
-				// 	/go/src/github.com/nre-learning/syringe/api/exp/livelessons.go:53 +0x86a
-				// github.com/nre-learning/syringe/api/exp/generated._LiveLessonsService_RequestLiveLesson_Handler(0x119d680, 0xc4201d0020, 0x1370700, 0xc4204563f0, 0xc4201de230, 0x0, 0x0, 0x0, 0xc4200eecf8, 0xf48563)
-				// 	/go/src/github.com/nre-learning/syringe/api/exp/generated/livelesson.pb.go:631 +0x241
-				// github.com/nre-learning/syringe/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc4201ca000, 0x137c420, 0xc420260000, 0xc42051ed00, 0xc4203de180, 0x1c775b8, 0x0, 0x0, 0x0)
-				// 	/go/src/github.com/nre-learning/syringe/vendor/google.golang.org/grpc/server.go:1011 +0x4fc
-				// github.com/nre-learning/syringe/vendor/google.golang.org/grpc.(*Server).handleStream(0xc4201ca000, 0x137c420, 0xc420260000, 0xc42051ed00, 0x0)
-				// 	/go/src/github.com/nre-learning/syringe/vendor/google.golang.org/grpc/server.go:1249 +0x1318
-				// github.com/nre-learning/syringe/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc4203b60c0, 0xc4201ca000, 0x137c420, 0xc420260000, 0xc42051ed00)
-				// 	/go/src/github.com/nre-learning/syringe/vendor/google.golang.org/grpc/server.go:680 +0x9f
-				// created by github.com/nre-learning/syringe/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
-				// 	/go/src/github.com/nre-learning/syringe/vendor/google.golang.org/grpc/server.go:678 +0xa1
+			// Update in-memory state
+			s.UpdateLiveLessonStage(lessonUuid, lp.LessonStage)
 
-				// Since this already existed, we don't need to update the sessions map, or the livelessons map
-				// Just update the stage and ready properties before sending modify request
-				s.liveLessons[lessonUuid].LessonStage = lp.LessonStage
-				s.liveLessons[lessonUuid].Ready = false
-
-				req := &scheduler.LessonScheduleRequest{
-					LessonDef: s.scheduler.LessonDefs[lp.LessonId],
-					Operation: scheduler.OperationType_MODIFY,
-					Stage:     lp.LessonStage,
-					Uuid:      lessonUuid,
-					Session:   lp.SessionId,
-				}
-
-				s.scheduler.Requests <- req
-
-				s.recordRequestTSDB(req)
-
-			} else {
-
-				// Nothing to do but the user did interact with this lesson so we should boop it.
-				req := &scheduler.LessonScheduleRequest{
-					LessonDef: s.scheduler.LessonDefs[lp.LessonId],
-					Operation: scheduler.OperationType_BOOP,
-					Stage:     0,
-					Uuid:      "",
-					Session:   lp.SessionId,
-				}
-
-				s.scheduler.Requests <- req
-
-				s.recordRequestTSDB(req)
+			// Request the schedule move forward with stage change activities
+			req := &scheduler.LessonScheduleRequest{
+				LessonDef: s.scheduler.LessonDefs[lp.LessonId],
+				Operation: scheduler.OperationType_MODIFY,
+				Stage:     lp.LessonStage,
+				Uuid:      lessonUuid,
+				Session:   lp.SessionId,
 			}
 
-			return &pb.LessonUUID{Id: lessonUuid}, nil
+			s.scheduler.Requests <- req
+
+			s.recordRequestTSDB(req)
+
 		} else {
-			log.Infof("session ID found but not for this lesson: %d", lp.LessonId)
+
+			// Nothing to do but the user did interact with this lesson so we should boop it.
+			req := &scheduler.LessonScheduleRequest{
+				LessonDef: s.scheduler.LessonDefs[lp.LessonId],
+				Operation: scheduler.OperationType_BOOP,
+				Stage:     0,
+				Uuid:      "",
+				Session:   lp.SessionId,
+			}
+
+			s.scheduler.Requests <- req
+
+			s.recordRequestTSDB(req)
 		}
-	} else {
 
-		// Doesn't exist, prep this spot with an empty map
-		log.Infof("Creating new session: %s", lp.SessionId)
-		s.sessions[lp.SessionId] = map[int32]string{}
+		return &pb.LessonUUID{Id: lessonUuid}, nil
 	}
-
-	// Generate UUID, make sure it doesn't conflict with another (unlikely but easy to check)
-	var newUuid string
-	for {
-		newUuid = GenerateUUID()
-		if _, ok := s.liveLessons[newUuid]; !ok {
-			break
-		}
-	}
-
-	// TODO(mierdin): consider not having any tables in memory at all. Just make everything function off of namespace names
-	// and literally store all state in kubernetes
-	//
-	// Ensure sessions table is updated with the new session
-	s.sessions[lp.SessionId][lp.LessonId] = newUuid
 
 	// 3 - if doesn't already exist, put together schedule request and send to channel
 	req := &scheduler.LessonScheduleRequest{
 		LessonDef: s.scheduler.LessonDefs[lp.LessonId],
 		Operation: scheduler.OperationType_CREATE,
 		Stage:     lp.LessonStage,
-		Uuid:      newUuid,
+		Uuid:      lessonUuid,
 		Created:   time.Now(),
 		Session:   lp.SessionId,
 	}
@@ -147,41 +108,15 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 
 	// Pre-emptively populate livelessons map with non-ready livelesson.
 	// This will be updated when the scheduler response comes back.
-	s.liveLessons[newUuid] = &pb.LiveLesson{Ready: false, LessonId: lp.LessonId, LessonUUID: newUuid, LessonStage: lp.LessonStage}
-	log.Infof("LiveLessons map: %v", s.liveLessons)
+	s.SetLiveLesson(lessonUuid, &pb.LiveLesson{Ready: false, LessonId: lp.LessonId, LessonUUID: lessonUuid, LessonStage: lp.LessonStage})
 
-	return &pb.LessonUUID{Id: newUuid}, nil
+	return &pb.LessonUUID{Id: lessonUuid}, nil
 }
 
-func (s *server) ListLiveLessons(ctx context.Context, _ *empty.Empty) (*pb.LiveLessonMap, error) {
-
-	// if _, ok := s.sessions[lp.SessionId]; ok {
-	// 	if lessonUuid, ok := s.sessions[lp.SessionId][lp.LessonId]; ok {
-
-	llm := pb.LiveLessonMap{}
-	// Sessions: make(map[int]pb.LessontoUUIDMap{
-	// 	Uuids: make(map[int32]pb.UUIDtoLiveLessonMap{
-	// 		LiveLessons: make(map[string]pb.LiveLesson{}),
-	// 	}),
-	// }),
-	// }
-	// liveLessons: make(map[string]*pb.LiveLesson),
-	// sessions:    make(map[string]map[int32]string),
-	llm.Sessions = make(map[string]*pb.LessontoUUIDMap)
-	for sessionId, lessons := range s.sessions {
-		llm.Sessions[sessionId] = &pb.LessontoUUIDMap{}
-		llm.Sessions[sessionId].Uuids = make(map[int32]*pb.UUIDtoLiveLessonMap)
-		for lessonId, uuid := range lessons {
-			llm.Sessions[sessionId].Uuids[lessonId] = &pb.UUIDtoLiveLessonMap{
-				Livelessons: map[string]*pb.LiveLesson{
-					uuid: s.liveLessons[uuid],
-				},
-			}
-
-		}
-	}
-
-	return &llm, nil
+func (s *server) GetSyringeState(ctx context.Context, _ *empty.Empty) (*pb.SyringeState, error) {
+	return &pb.SyringeState{
+		Livelessons: s.liveLessonState,
+	}, nil
 }
 
 func (s *server) HealthCheck(ctx context.Context, _ *empty.Empty) (*pb.HealthCheckMessage, error) {
@@ -196,11 +131,11 @@ func (s *server) GetLiveLesson(ctx context.Context, uuid *pb.LessonUUID) (*pb.Li
 		return nil, errors.New(msg)
 	}
 
-	if _, ok := s.liveLessons[uuid.Id]; !ok {
+	if !s.LiveLessonExists(uuid.Id) {
 		return nil, errors.New("livelesson not found")
 	}
 
-	ll := s.liveLessons[uuid.Id]
+	ll := s.liveLessonState[uuid.Id]
 
 	if ll.Error {
 		return nil, errors.New("Livelesson encountered errors during provisioning. See syringe logs")

--- a/api/exp/server.go
+++ b/api/exp/server.go
@@ -99,8 +99,6 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 	for {
 		result := <-ls.Results
 
-		log.Debugf(": %v", result)
-
 		log.WithFields(log.Fields{
 			"Operation": result.Operation,
 			"Success":   result.Success,

--- a/api/exp/server.go
+++ b/api/exp/server.go
@@ -2,17 +2,14 @@ package api
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"mime"
 	"net"
 	"net/http"
 	"os"
-	"regexp"
-	"strconv"
 	"strings"
+	"sync"
 
 	swag "github.com/nre-learning/syringe/api/exp/swagger"
 
@@ -37,20 +34,19 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 	}
 
 	apiServer := &server{
-		liveLessons: make(map[string]*pb.LiveLesson),
-		sessions:    make(map[string]map[int32]string),
-		scheduler:   ls,
-		buildInfo:   buildInfo,
+		liveLessonState: make(map[string]*pb.LiveLesson),
+		scheduler:       ls,
+		buildInfo:       buildInfo,
 	}
 
-	s := grpc.NewServer()
-	pb.RegisterLiveLessonsServiceServer(s, apiServer)
-	pb.RegisterLessonDefServiceServer(s, apiServer)
-	pb.RegisterSyringeInfoServiceServer(s, apiServer)
-	defer s.Stop()
+	grpcServer := grpc.NewServer()
+	pb.RegisterLiveLessonsServiceServer(grpcServer, apiServer)
+	pb.RegisterLessonDefServiceServer(grpcServer, apiServer)
+	pb.RegisterSyringeInfoServiceServer(grpcServer, apiServer)
+	defer grpcServer.Stop()
 
 	// Start grpc server
-	go s.Serve(lis)
+	go grpcServer.Serve(lis)
 
 	// Start REST proxy
 	ctx := context.Background()
@@ -87,7 +83,7 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", httpPort),
-		Handler: grpcHandlerFunc(s, mux),
+		Handler: grpcHandlerFunc(grpcServer, mux),
 	}
 	go srv.ListenAndServe()
 
@@ -105,39 +101,25 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 		log.Debugf("Received result message: %v", result)
 
 		if result.Success {
+
+			// Scheduler operation successful - just need to update the state in memory accordingly
 			if result.Operation == scheduler.OperationType_CREATE {
-
-				log.Debugf("Setting liveLesson %s: %v", result.Uuid, result.KubeLab.ToLiveLesson())
 				apiServer.recordProvisioningTime(result.ProvisioningTime, result)
-				apiServer.liveLessons[result.Uuid] = result.KubeLab.ToLiveLesson()
-			} else if result.Operation == scheduler.OperationType_DELETE {
-				delete(apiServer.liveLessons, result.Uuid)
+				apiServer.SetLiveLesson(result.Uuid, result.KubeLab.ToLiveLesson())
 			} else if result.Operation == scheduler.OperationType_MODIFY {
-				log.Debugf("Setting liveLesson %s: %v", result.Uuid, result.KubeLab.ToLiveLesson())
-				apiServer.liveLessons[result.Uuid] = result.KubeLab.ToLiveLesson()
-
+				apiServer.SetLiveLesson(result.Uuid, result.KubeLab.ToLiveLesson())
 			} else if result.Operation == scheduler.OperationType_GC {
 				for i := range result.GCLessons {
-					cleanedNs := result.GCLessons[i]
-					// 14-6viedvg5rctwdpcc-ns
-					lessonId, _ := strconv.ParseInt(strings.Split(cleanedNs, "-")[0], 10, 32)
-					sessionId := strings.Split(cleanedNs, "-")[1]
-
-					if _, ok := apiServer.sessions[sessionId]; ok {
-						if lessonUuid, ok := apiServer.sessions[sessionId][int32(lessonId)]; ok {
-
-							// Delete UUID from livelessons, and then delete from sessions map
-							delete(apiServer.liveLessons, lessonUuid)
-							delete(apiServer.sessions[sessionId], int32(lessonId))
-						}
-					}
+					uuid := strings.TrimRight(result.GCLessons[i], "-ns")
+					apiServer.DeleteLiveLesson(uuid)
 				}
+
 			} else {
 				log.Error("FOO")
 			}
 		} else {
 			log.Errorf("Problem encountered in request %s: %s", result.Uuid, result.Message)
-			apiServer.liveLessons[result.Uuid] = &pb.LiveLesson{Error: true}
+			apiServer.SetLiveLesson(result.Uuid, &pb.LiveLesson{Error: true})
 		}
 	}
 
@@ -149,14 +131,42 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 type server struct {
 
 	// in-memory map of liveLessons, indexed by UUID
-	liveLessons map[string]*pb.LiveLesson
+	// LiveLesson UUID is a string composed of the lesson ID and the session ID together,
+	// separated by a single hyphen. For instance, user session ID 582k2aidfjekxefi and lesson 19
+	// will result in 19-582k2aidfjekxefi.
+	liveLessonState map[string]*pb.LiveLesson
+	liveLessonsMu   *sync.Mutex
 
 	scheduler *scheduler.LessonScheduler
 
-	// map of session IDs maps containing lesson ID and corresponding lesson UUID
-	sessions map[string]map[int32]string
-
 	buildInfo map[string]string
+}
+
+func (s *server) LiveLessonExists(uuid string) bool {
+	_, ok := s.liveLessonState[uuid]
+	return ok
+}
+
+func (s *server) SetLiveLesson(uuid string, ll *pb.LiveLesson) {
+	s.liveLessonsMu.Lock()
+}
+
+func (s *server) UpdateLiveLessonStage(uuid string, stage int32) {
+	s.liveLessonsMu.Lock()
+	defer s.liveLessonsMu.Unlock()
+
+	s.liveLessonState[uuid].LessonStage = stage
+	s.liveLessonState[uuid].Ready = false
+}
+
+func (s *server) DeleteLiveLesson(uuid string) {
+	if _, ok := s.liveLessonState[uuid]; !ok {
+		// Nothing to do
+		return
+	}
+	s.liveLessonsMu.Lock()
+	defer s.liveLessonsMu.Unlock()
+	delete(s.liveLessonState, uuid)
 }
 
 // grpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
@@ -189,41 +199,4 @@ func serveSwagger(mux *http.ServeMux) {
 	})
 	prefix := "/swagger/"
 	mux.Handle(prefix, http.StripPrefix(prefix, fileServer))
-}
-
-var validShortID = regexp.MustCompile("^[a-z0-9]{12}$")
-
-// IsShortID determine if an arbitrary string *looks like* a short ID.
-func IsShortID(id string) bool {
-	return validShortID.MatchString(id)
-}
-
-// TruncateID returns a shorthand version of a string identifier for convenience.
-// A collision with other shorthands is very unlikely, but possible.
-// In case of a collision a lookup with TruncIndex.Get() will fail, and the caller
-// will need to use a langer prefix, or the full-length Id.
-func TruncateID(id string) string {
-	trimTo := 12
-	if len(id) < trimTo {
-		trimTo = len(id)
-	}
-	return id[:trimTo]
-}
-
-// GenerateUUID returns an unique id
-func GenerateUUID() string {
-	for {
-		id := make([]byte, 32)
-		if _, err := io.ReadFull(rand.Reader, id); err != nil {
-			panic(err) // This shouldn't happen
-		}
-		value := hex.EncodeToString(id)
-		// if we try to parse the truncated for as an int and we don't have
-		// an error then the value is all numberic and causes issues when
-		// used as a hostname. ref #3869
-		if _, err := strconv.ParseInt(TruncateID(value), 10, 64); err == nil {
-			continue
-		}
-		return value
-	}
 }

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -332,23 +332,6 @@ Livelesson = `{
           "LiveLessonsService"
         ]
       }
-    },
-    "/exp/livelessonall": {
-      "get": {
-        "summary": "Retrieve all livelessons",
-        "operationId": "ListLiveLessons",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/expLiveLessonMap"
-            }
-          }
-        },
-        "tags": [
-          "LiveLessonsService"
-        ]
-      }
     }
   },
   "definitions": {
@@ -388,17 +371,6 @@ Livelesson = `{
       "properties": {
         "id": {
           "type": "string"
-        }
-      }
-    },
-    "expLessontoUUIDMap": {
-      "type": "object",
-      "properties": {
-        "Uuids": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/expUUIDtoLiveLessonMap"
-          }
         }
       }
     },
@@ -471,25 +443,22 @@ Livelesson = `{
       },
       "description": "A provisioned lab without the scheduler details. The server will translate from an underlying type\n(i.e. KubeLab) into this, so only the abstract, relevant details are presented."
     },
-    "expLiveLessonMap": {
-      "type": "object",
-      "properties": {
-        "Sessions": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/expLessontoUUIDMap"
-          }
-        }
-      }
-    },
-    "expUUIDtoLiveLessonMap": {
+    "expSyringeState": {
       "type": "object",
       "properties": {
         "Livelessons": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/expLiveLesson"
-          }
+          },
+          "title": "Map that contains a mapping of UUIDs to LiveLesson messages"
+        },
+        "Sessions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Map that contains a mapping of session IDs (19-abcdef) to LiveLesson UUID maps"
         }
       }
     }

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -427,9 +427,6 @@ Livelesson = `{
           "type": "string",
           "format": "date-time"
         },
-        "sessionId": {
-          "type": "string"
-        },
         "LessonDiagram": {
           "type": "string"
         },
@@ -452,13 +449,6 @@ Livelesson = `{
             "$ref": "#/definitions/expLiveLesson"
           },
           "title": "Map that contains a mapping of UUIDs to LiveLesson messages"
-        },
-        "Sessions": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Map that contains a mapping of session IDs (19-abcdef) to LiveLesson UUID maps"
         }
       }
     }

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -55,7 +55,7 @@ func (ls *LessonScheduler) killAllJobs(nsName string) error {
 
 func (ls *LessonScheduler) isCompleted(job *batchv1.Job, req *LessonScheduleRequest) (bool, error) {
 
-	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonId, req.Session)
+	nsName := fmt.Sprintf("%s-ns", req.Uuid)
 
 	batchclient, err := batchv1client.NewForConfig(ls.KubeConfig)
 	if err != nil {
@@ -99,7 +99,7 @@ func (ls *LessonScheduler) configureDevice(ep *pb.LiveEndpoint, req *LessonSched
 		panic(err)
 	}
 
-	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonId, req.Session)
+	nsName := fmt.Sprintf("%s-ns", req.Uuid)
 
 	jobName := fmt.Sprintf("config-%s", ep.GetName())
 	podName := fmt.Sprintf("config-%s", ep.GetName())
@@ -110,7 +110,6 @@ func (ls *LessonScheduler) configureDevice(ep *pb.LiveEndpoint, req *LessonSched
 			Namespace: nsName,
 			Labels: map[string]string{
 				"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
-				"sessionId":      req.Session,
 				"syringeManaged": "yes",
 				"stageId":        strconv.Itoa(int(req.Stage)),
 			},
@@ -123,7 +122,6 @@ func (ls *LessonScheduler) configureDevice(ep *pb.LiveEndpoint, req *LessonSched
 					Namespace: nsName,
 					Labels: map[string]string{
 						"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
-						"sessionId":      req.Session,
 						"syringeManaged": "yes",
 						"stageId":        strconv.Itoa(int(req.Stage)),
 					},

--- a/scheduler/namespaces.go
+++ b/scheduler/namespaces.go
@@ -119,16 +119,15 @@ func (ls *LessonScheduler) createNamespace(req *LessonScheduleRequest) (*corev1.
 		panic(err)
 	}
 
-	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonId, req.Session)
+	nsName := fmt.Sprintf("%s-ns", req.Uuid)
 
-	log.Infof("Creating namespace: %s", req.Session)
+	log.Infof("Creating namespace: %s", nsName)
 
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
 			Labels: map[string]string{
 				"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
-				"sessionId":      req.Session,
 				"syringeManaged": "yes",
 				"syringeTier":    ls.SyringeConfig.Tier,
 				"lastAccessed":   strconv.Itoa(int(time.Now().Unix())),

--- a/scheduler/networks.go
+++ b/scheduler/networks.go
@@ -159,7 +159,7 @@ func (ls *LessonScheduler) createNetwork(netName string, req *LessonScheduleRequ
 		panic(err)
 	}
 
-	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonId, req.Session)
+	nsName := fmt.Sprintf("%s-ns", req.Uuid)
 
 	// Create a CRD client interface
 	crdclient := client.CrdClient(crdcs, scheme, nsName)
@@ -170,9 +170,9 @@ func (ls *LessonScheduler) createNetwork(netName string, req *LessonScheduleRequ
 	strLid := strconv.Itoa(int(req.LessonDef.LessonId))
 	chars := 12 - len(strLid)
 
-	bridgeName := fmt.Sprintf("%s-%s", strLid, req.Session)
-	if len(req.Session) > chars {
-		bridgeName = fmt.Sprintf("%s-%s", strLid, req.Session[0:chars])
+	bridgeName := fmt.Sprintf("%s-%s", strLid, req.Uuid)
+	if len(req.Uuid) > chars {
+		bridgeName = fmt.Sprintf("%s-%s", strLid, req.Uuid[0:chars])
 	}
 
 	networkArgs := fmt.Sprintf(`{
@@ -199,7 +199,6 @@ func (ls *LessonScheduler) createNetwork(netName string, req *LessonScheduleRequ
 			Namespace: nsName,
 			Labels: map[string]string{
 				"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
-				"sessionId":      req.Session,
 				"syringeManaged": "yes",
 			},
 		},

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -27,7 +27,7 @@ func (ls *LessonScheduler) createPod(ep Endpoint, etype pb.LiveEndpoint_Endpoint
 		panic(err)
 	}
 
-	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonId, req.Session)
+	nsName := fmt.Sprintf("%s-ns", req.Uuid)
 
 	b := true
 
@@ -49,7 +49,6 @@ func (ls *LessonScheduler) createPod(ep Endpoint, etype pb.LiveEndpoint_Endpoint
 			Namespace: nsName,
 			Labels: map[string]string{
 				"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
-				"sessionId":      req.Session,
 				"endpointType":   etype.String(),
 				"podName":        ep.GetName(),
 				"syringeManaged": "yes",
@@ -71,7 +70,6 @@ func (ls *LessonScheduler) createPod(ep Endpoint, etype pb.LiveEndpoint_Endpoint
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
-									"sessionId":      req.Session,
 									"syringeManaged": "yes",
 								},
 							},

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -184,7 +184,7 @@ func (ls *LessonScheduler) handleRequest(newRequest *LessonScheduleRequest) {
 				}
 			}
 		} else {
-			log.Infof("Skipping configuration of new instance of lesson %d", newRequest.LessonDef.LessonId)
+			log.Infof("Nothing to configure in %s", newRequest.Uuid)
 		}
 
 		// Finish locking down networkpolicy now that lesson is online and reachable

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -28,10 +28,9 @@ type OperationType int32
 
 var (
 	OperationType_CREATE OperationType = 0
-	OperationType_DELETE OperationType = 1
-	OperationType_MODIFY OperationType = 2
-	OperationType_BOOP   OperationType = 3
-	OperationType_GC     OperationType = 4
+	OperationType_MODIFY OperationType = 1
+	OperationType_BOOP   OperationType = 2
+	OperationType_GC     OperationType = 3
 	// _typePortMap                       = map[string]int32{
 	// 	"DEVICE":  22,
 	// 	"UTILITY": 22,
@@ -197,25 +196,6 @@ func (ls *LessonScheduler) handleRequest(newRequest *LessonScheduleRequest) {
 			ProvisioningTime: int(time.Since(newRequest.Created).Seconds()),
 			Operation:        newRequest.Operation,
 			Stage:            newRequest.Stage,
-		}
-	} else if newRequest.Operation == OperationType_DELETE {
-		err := ls.deleteNamespace(nsName)
-		if err != nil {
-			log.Errorf("Error deleting lesson: %s", err)
-			ls.Results <- &LessonScheduleResult{
-				Success:   false,
-				LessonDef: newRequest.LessonDef,
-				KubeLab:   nil,
-				Uuid:      "",
-				Operation: newRequest.Operation,
-			}
-		}
-		ls.Results <- &LessonScheduleResult{
-			Success:   true,
-			LessonDef: newRequest.LessonDef,
-			KubeLab:   nil,
-			Uuid:      newRequest.Uuid,
-			Operation: newRequest.Operation,
 		}
 	} else if newRequest.Operation == OperationType_MODIFY {
 

--- a/scheduler/services.go
+++ b/scheduler/services.go
@@ -26,26 +26,22 @@ func (ls *LessonScheduler) createService(pod *corev1.Pod, req *LessonScheduleReq
 	// (i.e. use "vqfx1" instead of "vqfx1-svc" or something like that.)
 	serviceName := pod.ObjectMeta.Name
 
-	nsName := fmt.Sprintf("%d-%s-ns", req.LessonDef.LessonId, req.Session)
+	nsName := fmt.Sprintf("%s-ns", req.Uuid)
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: nsName,
 			Labels: map[string]string{
-				"lessonId":         fmt.Sprintf("%d", req.LessonDef.LessonId),
-				"lessonInstanceId": req.Session,
-				"syringeManaged":   "yes",
-				"endpointType":     pod.ObjectMeta.Labels["endpointType"],
-				"sshUser":          pod.ObjectMeta.Labels["sshUser"],
-				"sshPassword":      pod.ObjectMeta.Labels["sshPassword"],
+				"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
+				"syringeManaged": "yes",
+				"endpointType":   pod.ObjectMeta.Labels["endpointType"],
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"lessonId":  fmt.Sprintf("%d", req.LessonDef.LessonId),
-				"sessionId": req.Session,
-				"podName":   pod.ObjectMeta.Name,
+				"lessonId": fmt.Sprintf("%d", req.LessonDef.LessonId),
+				"podName":  pod.ObjectMeta.Name,
 			},
 			Ports: []corev1.ServicePort{}, // will fill out below
 


### PR DESCRIPTION
- Simplify in-memory state model by removing the session map, and using a combined lesson+session ID to form the UUID that's used to track each LiveLesson. This allows us to store all state in a single map, while retaining the same amount of detail.
- Protect this state by controlling access through functions that use a mutex, for safe concurrent updates.

Closes https://github.com/nre-learning/syringe/issues/7