### PR TITLE
Introduce garbage collection whitelist functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Simplified authentication by using consistent credentials, statically [#40](https://github.com/nre-learning/syringe/pull/40)
 - Serve lab guide directly from lesson definition API [#41](https://github.com/nre-learning/syringe/pull/41)
 - Simplify and improve safety of in-memory state model [#42](https://github.com/nre-learning/syringe/pull/42)
+- Introduce garbage collection whitelist functionality [#45](https://github.com/nre-learning/syringe/pull/45)
 
 ## 0.1.4 - January 08, 2019
 

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -28,9 +28,19 @@ service LiveLessonsService {
     };
   }
 
-  // Retrieve all livelessons
-  // SENSITIVE - do not expose via REST
+  // THESE ARE SENSITIVE - do not expose via REST
   rpc GetSyringeState(google.protobuf.Empty) returns (SyringeState) {}
+  rpc AddSessiontoGCWhitelist(Session) returns (HealthCheckMessage) {}
+  rpc RemoveSessionFromGCWhitelist(Session) returns (HealthCheckMessage) {}
+  rpc GetGCWhitelist(google.protobuf.Empty) returns (Sessions) {}
+}
+
+message Session {
+  string id = 1;
+}
+
+message Sessions {
+  repeated Session sessions = 1;
 }
 
 message HealthCheckMessage {}

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -190,6 +190,25 @@
       },
       "description": "A provisioned lab without the scheduler details. The server will translate from an underlying type\n(i.e. KubeLab) into this, so only the abstract, relevant details are presented."
     },
+    "expSession": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "expSessions": {
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expSession"
+          }
+        }
+      }
+    },
     "expSyringeState": {
       "type": "object",
       "properties": {

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -440,6 +440,25 @@ Livelesson = `{
       },
       "description": "A provisioned lab without the scheduler details. The server will translate from an underlying type\n(i.e. KubeLab) into this, so only the abstract, relevant details are presented."
     },
+    "expSession": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "expSessions": {
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expSession"
+          }
+        }
+      }
+    },
     "expSyringeState": {
       "type": "object",
       "properties": {

--- a/cmd/syringed/main.go
+++ b/cmd/syringed/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"sync"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	api "github.com/nre-learning/syringe/api/exp"
+	pb "github.com/nre-learning/syringe/api/exp/generated"
 	config "github.com/nre-learning/syringe/config"
 	"github.com/nre-learning/syringe/scheduler"
 	log "github.com/sirupsen/logrus"
@@ -44,6 +46,8 @@ func main() {
 		Results:       make(chan *scheduler.LessonScheduleResult),
 		LessonDefs:    lessonDefs,
 		SyringeConfig: syringeConfig,
+		GcWhiteList:   make(map[string]*pb.Session),
+		GcWhiteListMu: &sync.Mutex{},
 	}
 	go func() {
 		err = lessonScheduler.Start()

--- a/scheduler/networks.go
+++ b/scheduler/networks.go
@@ -177,8 +177,8 @@ func (ls *LessonScheduler) createNetwork(netName string, req *LessonScheduleRequ
 
 	networkArgs := fmt.Sprintf(`{
 			"name": "%s",
-			"type": "bridge",
-			"plugin": "bridge",
+			"type": "antibridge",
+			"plugin": "antibridge",
 			"bridge": "%s",
 			"forceAddress": false,
 			"hairpinMode": false,

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -73,6 +73,8 @@ type LessonScheduler struct {
 	Results       chan *LessonScheduleResult
 	LessonDefs    map[int32]*pb.LessonDef
 	SyringeConfig *config.SyringeConfig
+	GcWhiteList   map[string]*pb.Session
+	GcWhiteListMu *sync.Mutex
 }
 
 // Start is meant to be run as a goroutine. The "requests" channel will wait for new requests, attempt to schedule them,


### PR DESCRIPTION
Sometimes, especially for demos, it's necessary to prevent a lesson from being destroyed at the configured garbage collection interval.

This PR introduces a new gRPC service (not available through the REST gateway for security reasons) and accompanying client commands for adding session IDs to an in-memory whitelist. At each garbage-collection interval, this list will be consulted before cleaning up a lesson. If the lesson contains a session ID in this list, it will not be cleaned up.

This lasts as long as `syringed` is running, so this doesn't effect the "nuke" behavior at syringe startup, and since it's in memory, the whitelist is not kept persistently.

This closes #44 