### PR TITLE
Fixed bug with bridge naming and reachability timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Serve lab guide directly from lesson definition API [#41](https://github.com/nre-learning/syringe/pull/41)
 - Simplify and improve safety of in-memory state model [#42](https://github.com/nre-learning/syringe/pull/42)
 - Introduce garbage collection whitelist functionality [#45](https://github.com/nre-learning/syringe/pull/45)
+- Fixed bug with bridge naming and reachability timeout [#51](https://github.com/nre-learning/syringe/pull/51)
 
 ## 0.1.4 - January 08, 2019
 


### PR DESCRIPTION
Fixing two bugs:

## Fix Bridge Naming

The bridge naming in light of #42 is skewed. In addition, the unique indicator within the bridge name was at the end of the string, which always ended up being more than 15 characters, which is the length limit for linux bridges. This caused multiple networks to get placed on the same underlying bridge. We haven't used anything other than unicast traffic thus far so I didn't notice it, but after testing LLDP, I discovered everything was plugged into the same bridge

I'm now assigning a numerical index to each network, and putting that at the beginning of the bridge name, along with the lesson ID. The session ID fills out the remaining characters.

## Un-executed reachability error

In the loop where syringe retries to contact the lesson endpoints, the exit condition is `i < 600`. However, the conditional that triggers the return of an error to the channel only executes at `i > 600`. These are mutually exclusive, and the loop will exit before that conditional ever evaluates to true.

I could have modified the conditional, but elected to move it below the loop and have the loop set a boolean variable to true if it was able to contact the lesson endpoints. If it doesn't, the value will remain `false` and the error will be sent to the channel to the API.