### PR TITLE
Add more detail around the status of a livelesson's startup progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Simplify and improve safety of in-memory state model [#42](https://github.com/nre-learning/syringe/pull/42)
 - Introduce garbage collection whitelist functionality [#45](https://github.com/nre-learning/syringe/pull/45)
 - Fixed bug with bridge naming and reachability timeout [#51](https://github.com/nre-learning/syringe/pull/51)
+- Add more detail around the status of a livelesson's startup progress [#52](https://github.com/nre-learning/syringe/pull/52)
 
 ## 0.1.4 - January 08, 2019
 

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -52,15 +52,24 @@ message SyringeState {
 
 }
 
+enum Status {
+  DONOTUSE = 0;   // Protobuf doesn't encode the default value. Throwing this one away.
+  INITIAL_BOOT = 1;
+  CONFIGURATION = 2;
+  READY = 3;
+}
+
 // A provisioned lab without the scheduler details. The server will translate from an underlying type
 // (i.e. KubeLab) into this, so only the abstract, relevant details are presented.
 message LiveLesson {
   string LessonUUID = 1;
   int32 LessonId = 2;
-  repeated LiveEndpoint LiveEndpoints  = 3;
+  map <string, LiveEndpoint> LiveEndpoints  = 3;
   int32 LessonStage = 4;
   string LabGuide = 5;
-  bool Ready = 6;
+
+  Status LiveLessonStatus = 6;
+
   google.protobuf.Timestamp createdTime = 7;
   string LessonDiagram = 8;
   string LessonVideo = 9;
@@ -87,6 +96,7 @@ message LiveEndpoint {
 
   string IframePath = 5;
 
+  bool Reachable = 6;
 }
 
 message LessonParams {

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -143,6 +143,10 @@
         },
         "IframePath": {
           "type": "string"
+        },
+        "Reachable": {
+          "type": "boolean",
+          "format": "boolean"
         }
       }
     },
@@ -157,8 +161,8 @@
           "format": "int32"
         },
         "LiveEndpoints": {
-          "type": "array",
-          "items": {
+          "type": "object",
+          "additionalProperties": {
             "$ref": "#/definitions/expLiveEndpoint"
           }
         },
@@ -169,9 +173,8 @@
         "LabGuide": {
           "type": "string"
         },
-        "Ready": {
-          "type": "boolean",
-          "format": "boolean"
+        "LiveLessonStatus": {
+          "$ref": "#/definitions/expStatus"
         },
         "createdTime": {
           "type": "string",
@@ -208,6 +211,16 @@
           }
         }
       }
+    },
+    "expStatus": {
+      "type": "string",
+      "enum": [
+        "DONOTUSE",
+        "INITIAL_BOOT",
+        "CONFIGURATION",
+        "READY"
+      ],
+      "default": "DONOTUSE"
     },
     "expSyringeState": {
       "type": "object",

--- a/api/exp/server.go
+++ b/api/exp/server.go
@@ -118,7 +118,6 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 					uuid := strings.TrimRight(result.GCLessons[i], "-ns")
 					apiServer.DeleteLiveLesson(uuid)
 				}
-
 			} else {
 				log.Error("FOO")
 			}
@@ -164,7 +163,7 @@ func (s *server) UpdateLiveLessonStage(uuid string, stage int32) {
 	defer s.liveLessonsMu.Unlock()
 
 	s.liveLessonState[uuid].LessonStage = stage
-	s.liveLessonState[uuid].Ready = false
+	s.liveLessonState[uuid].LiveLessonStatus = pb.Status_CONFIGURATION
 }
 
 func (s *server) DeleteLiveLesson(uuid string) {

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -393,6 +393,10 @@ Livelesson = `{
         },
         "IframePath": {
           "type": "string"
+        },
+        "Reachable": {
+          "type": "boolean",
+          "format": "boolean"
         }
       }
     },
@@ -407,8 +411,8 @@ Livelesson = `{
           "format": "int32"
         },
         "LiveEndpoints": {
-          "type": "array",
-          "items": {
+          "type": "object",
+          "additionalProperties": {
             "$ref": "#/definitions/expLiveEndpoint"
           }
         },
@@ -419,9 +423,8 @@ Livelesson = `{
         "LabGuide": {
           "type": "string"
         },
-        "Ready": {
-          "type": "boolean",
-          "format": "boolean"
+        "LiveLessonStatus": {
+          "$ref": "#/definitions/expStatus"
         },
         "createdTime": {
           "type": "string",
@@ -458,6 +461,16 @@ Livelesson = `{
           }
         }
       }
+    },
+    "expStatus": {
+      "type": "string",
+      "enum": [
+        "DONOTUSE",
+        "INITIAL_BOOT",
+        "CONFIGURATION",
+        "READY"
+      ],
+      "default": "DONOTUSE"
     },
     "expSyringeState": {
       "type": "object",


### PR DESCRIPTION
Previously, the Syringe API only provided a single field: `Ready`, to indicate whether a LiveLesson was indeed ready. This presented a big UX problem

The LiveLesson now has a `LiveLessonStatus` field, which can be one of three values:

- `INITIAL_BOOT`
- `CONFIGURATION`
- `READY`

This describes the overall lifecycle of a LiveLesson, and allows the front-end to better indicate to the user where the LiveLesson is at in it's progress towards readiness.

In addition to having a Status for the LiveLesson itself, the lesson's endpoints also make use of this same enum, so that the API can inform the front end which endpoints have finished starting. This provides further granularity beyond the `INITIAL_BOOT` phase, by providing insight into exactly how many endpoints are started, and how many haven't yet.

I elected not to provide per-endpoint status for the configuration phase, mainly to keep the complexity of the change low, and because the time spent in the `INITIAL_BOOT` phase is likely to be the one keeping folks guessing. Once everything is booted, it's far less likely that the configuration phase will take very long or have problems. However, because the `Status` enum is agnostic, it could be again re-used for that purpose.

Closes https://github.com/nre-learning/syringe/issues/49