### PR TITLE
Add check to lesson import to ensure lesson IDs are unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Introduce garbage collection whitelist functionality [#45](https://github.com/nre-learning/syringe/pull/45)
 - Fixed bug with bridge naming and reachability timeout [#51](https://github.com/nre-learning/syringe/pull/51)
 - Add more detail around the status of a livelesson's startup progress [#52](https://github.com/nre-learning/syringe/pull/52)
+- Add check to lesson import to ensure lesson IDs are unique [#53](https://github.com/nre-learning/syringe/pull/53)
 
 ## 0.1.4 - January 08, 2019
 

--- a/api/exp/lessondefs.go
+++ b/api/exp/lessondefs.go
@@ -49,17 +49,6 @@ func (s *server) GetLessonDef(ctx context.Context, lid *pb.LessonID) (*pb.Lesson
 	return lessonDef, nil
 }
 
-// JSON exports the lesson definition as JSON
-// func (ld *pb.LessonDef) JSON() string {
-// 	lessonJSON, err := json.MarshalIndent(ld, "", "  ")
-// 	if err != nil {
-// 		log.Error(err)
-// 		return ""
-// 	}
-
-// 	return string(lessonJSON)
-// }
-
 func ImportLessonDefs(syringeConfig *config.SyringeConfig, lessonDir string) (map[int32]*pb.LessonDef, error) {
 
 	// Get lesson definitions
@@ -101,6 +90,11 @@ FILES:
 		err = lessonDef.Validate()
 		if err != nil {
 			log.Errorf("Basic validation failed on %s: %s", file, err)
+			continue FILES
+		}
+
+		if _, ok := retLds[lessonDef.LessonId]; ok {
+			log.Errorf("Failed to import %s: Lesson ID %d already exists in another lesson definition.", file, lessonDef.LessonId)
 			continue FILES
 		}
 


### PR DESCRIPTION
This PR adds a basic check to make sure every lesson definition has a unique ID on import. This will be especially useful when using `syrctl` to validate new lesson contributions have a unique lesson ID.