### PR TITLE
Fix fundamentally broken networkpolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add more detail around the status of a livelesson's startup progress [#52](https://github.com/nre-learning/syringe/pull/52)
 - Add check to lesson import to ensure lesson IDs are unique [#53](https://github.com/nre-learning/syringe/pull/53)
 - Use new githelper image instead of configmap script [#55](https://github.com/nre-learning/syringe/pull/55)
+- Fix fundamentally broken networkpolicy [#58](https://github.com/nre-learning/syringe/pull/58)
 
 ## 0.1.4 - January 08, 2019
 

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -123,6 +123,7 @@ func (ls *LessonScheduler) configureDevice(ep *pb.LiveEndpoint, req *LessonSched
 					Labels: map[string]string{
 						"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
 						"syringeManaged": "yes",
+						"configPod":      "yes",
 						"stageId":        strconv.Itoa(int(req.Stage)),
 					},
 				},

--- a/scheduler/namespaces.go
+++ b/scheduler/namespaces.go
@@ -130,6 +130,7 @@ func (ls *LessonScheduler) createNamespace(req *LessonScheduleRequest) (*corev1.
 			Labels: map[string]string{
 				"lessonId":       fmt.Sprintf("%d", req.LessonDef.LessonId),
 				"syringeManaged": "yes",
+				"name": nsName,
 				"syringeTier":    ls.SyringeConfig.Tier,
 				"lastAccessed":   strconv.Itoa(int(time.Now().Unix())),
 				"created":        strconv.Itoa(int(time.Now().Unix())),


### PR DESCRIPTION
Previously, the network policy that Syringe placed on a lesson's namespace was too restrictive. It disabled internet access for ALL pods, including the configuration pods spun up by Syringe via Jobs API.

This caused subsequent reconfigurations to fail, since the policy was applied at the end of the initial lesson spin-up. The lesson would load, but going to a new stage would time out, as the configuration pods couldn't reach github.

This PR appends a special label to these pods, and adjusts the network policy so that configuration pods will continue to have internet access after the policy is in place.