### PR TITLE
Re-vamp internal state systems and add external observability functions for livelessons and kubelabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed GC goroutine; make GC interval configurable [#63](https://github.com/nre-learning/syringe/pull/63)
 - Add jupyter notebook as lab guide functionality [#67](https://github.com/nre-learning/syringe/pull/67)
 - Added ability to perform completion verifications on livelessons [#69](https://github.com/nre-learning/syringe/pull/69)
+- Re-vamp internal state systems and add external observability functions for livelessons and kubelabs [#68](https://github.com/nre-learning/syringe/pull/68)
 
 ## 0.2.0 - January 24, 2019
 

--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,11 @@ clean:
 compile:
 
 	@echo "Generating protobuf code..."
-
 	@rm -f pkg/ui/data/swagger/datafile.go
-
 	@rm -f /tmp/datafile.go
 	@rm -f cmd/syringed/buildinfo.go
-
 	@rm -rf api/exp/generated/ && mkdir -p api/exp/generated/
-
-	@protoc -I api/exp/definitions/ -I. \
-	-I api/exp/definitions/ \
-	  api/exp/definitions/*.proto \
-		-I$$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
-		-I$$GOPATH/src/github.com/lyft/protoc-gen-validate \
-	--go_out=plugins=grpc:api/exp/generated/ \
-    --grpc-gateway_out=logtostderr=true,allow_delete_body=true:api/exp/generated/ \
-    --validate_out=lang=go:api/exp/generated/ \
-	--swagger_out=logtostderr=true,allow_delete_body=true:api/exp/definitions/
+	@./compile-proto.sh
 
 	@# Adding equivalent YAML tags so we can import lesson definitions into protobuf-created structs
 	@sed -i'.bak' -e 's/\(protobuf.*json\):"\([^,]*\)/\1:"\2,omitempty" yaml:"\l\2/' api/exp/generated/lessondef.pb.go

--- a/api/exp/definitions/kubelab.proto
+++ b/api/exp/definitions/kubelab.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+package syringe.api.exp;
+
+import "livelesson.proto";
+import "lessondef.proto";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+service KubeLabService {
+
+  rpc ListKubeLabs(google.protobuf.Empty) returns (KubeLabs) {}
+  rpc GetKubeLab(KubeLabUuid) returns (KubeLab) {}
+
+}
+
+message KubeLabUuid {
+    string Id = 1;
+}
+
+message LessonScheduleRequest {
+    LessonDef LessonDef = 1;
+    int32 OperationType = 2;
+    string Uuid = 3;
+    int32 Stage = 4;
+    google.protobuf.Timestamp Created = 5;
+}
+
+message KubeLab {
+    string Namespace = 1;
+    LessonScheduleRequest CreateRequest = 2;
+    repeated string Networks = 3;
+    repeated string Pods = 4;
+    repeated string Services = 5;
+    repeated string Ingresses = 6;
+    Status status = 7;
+    repeated string ReachableEndpoints = 8;
+    int32 CurrentStage = 9;
+}
+
+message KubeLabs {
+    map<string, KubeLab> Items = 1;
+}
+
+

--- a/api/exp/definitions/kubelab.swagger.json
+++ b/api/exp/definitions/kubelab.swagger.json
@@ -1,0 +1,307 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "kubelab.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "expBlackbox": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "Ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "expConnection": {
+      "type": "object",
+      "properties": {
+        "A": {
+          "type": "string"
+        },
+        "B": {
+          "type": "string"
+        },
+        "Subnet": {
+          "type": "string"
+        }
+      }
+    },
+    "expDevice": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "Ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "expIframeResource": {
+      "type": "object",
+      "properties": {
+        "Ref": {
+          "type": "string"
+        },
+        "Protocol": {
+          "type": "string"
+        },
+        "Path": {
+          "type": "string"
+        },
+        "Port": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "expKubeLab": {
+      "type": "object",
+      "properties": {
+        "Namespace": {
+          "type": "string"
+        },
+        "CreateRequest": {
+          "$ref": "#/definitions/expLessonScheduleRequest"
+        },
+        "Networks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Pods": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Services": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Ingresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/expStatus"
+        },
+        "ReachableEndpoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "CurrentStage": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "expKubeLabs": {
+      "type": "object",
+      "properties": {
+        "Items": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/expKubeLab"
+          }
+        }
+      }
+    },
+    "expLessonDef": {
+      "type": "object",
+      "properties": {
+        "LessonId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Stages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expLessonStage"
+          }
+        },
+        "LessonName": {
+          "type": "string"
+        },
+        "IframeResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expIframeResource"
+          }
+        },
+        "Devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expDevice"
+          }
+        },
+        "Utilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expUtility"
+          }
+        },
+        "Blackboxes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expBlackbox"
+          }
+        },
+        "Connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expConnection"
+          }
+        },
+        "Category": {
+          "type": "string"
+        },
+        "LessonDiagram": {
+          "type": "string"
+        },
+        "LessonVideo": {
+          "type": "string"
+        },
+        "Tier": {
+          "type": "string"
+        },
+        "Prereqs": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Collection": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Slug": {
+          "type": "string",
+          "title": "This is meant to fill: \"How well do you know \u003cslug\u003e?\""
+        }
+      }
+    },
+    "expLessonScheduleRequest": {
+      "type": "object",
+      "properties": {
+        "LessonDef": {
+          "$ref": "#/definitions/expLessonDef"
+        },
+        "OperationType": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Uuid": {
+          "type": "string"
+        },
+        "Stage": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Created": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "expLessonStage": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "LabGuide": {
+          "type": "string"
+        },
+        "JupyterLabGuide": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "VerifyCompleteness": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "VerifyObjective": {
+          "type": "string"
+        }
+      }
+    },
+    "expStatus": {
+      "type": "string",
+      "enum": [
+        "DONOTUSE",
+        "INITIAL_BOOT",
+        "CONFIGURATION",
+        "READY"
+      ],
+      "default": "DONOTUSE"
+    },
+    "expUtility": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "Ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -141,12 +141,7 @@ message LessonParams {
 message LessonUUID {
   string id = 1;
 }
-<<<<<<< HEAD
 
 message KillLiveLessonStatus {
   bool success = 1;
 }
-
-
-=======
->>>>>>> master

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -33,6 +33,8 @@ service LiveLessonsService {
   rpc AddSessiontoGCWhitelist(Session) returns (HealthCheckMessage) {}
   rpc RemoveSessionFromGCWhitelist(Session) returns (HealthCheckMessage) {}
   rpc GetGCWhitelist(google.protobuf.Empty) returns (Sessions) {}
+  rpc ListLiveLessons(google.protobuf.Empty) returns (LiveLessons) {}
+  rpc KillLiveLesson(LessonUUID) returns (KillLiveLessonStatus) {}
 }
 
 message Session {
@@ -77,6 +79,10 @@ message LiveLesson {
   bool Error = 11;
 }
 
+message LiveLessons {
+  map<string, LiveLesson> items = 1;
+}
+
 message LiveEndpoint {
   string Name  = 1;
 
@@ -108,6 +114,10 @@ message LessonParams {
 
 message LessonUUID {
   string id = 1;
+}
+
+message KillLiveLessonStatus {
+  bool success = 1;
 }
 
 

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -100,6 +100,15 @@
     "expHealthCheckMessage": {
       "type": "object"
     },
+    "expKillLiveLessonStatus": {
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
     "expLessonParams": {
       "type": "object",
       "properties": {
@@ -196,6 +205,17 @@
         }
       },
       "description": "A provisioned lab without the scheduler details. The server will translate from an underlying type\n(i.e. KubeLab) into this, so only the abstract, relevant details are presented."
+    },
+    "expLiveLessons": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/expLiveLesson"
+          }
+        }
+      }
     },
     "expSession": {
       "type": "object",

--- a/api/exp/influxdb.go
+++ b/api/exp/influxdb.go
@@ -188,6 +188,11 @@ func (s *server) startTSDBExport() error {
 			}
 			fields["activeNow"] = count
 
+			// This is just for debugging, so only show active lessons
+			if count > 0 {
+				log.Debugf("Creating influxdb point: ID: %s | NAME: %s | ACTIVE: %d", fields["lessonId"], fields["lessonName"], count)
+			}
+
 			pt, err := influx.NewPoint("sessionStatus", tags, fields, time.Now())
 			if err != nil {
 				log.Error("Error creating InfluxDB Point: ", err)

--- a/api/exp/kubelabs.go
+++ b/api/exp/kubelabs.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+)
+
+func (s *server) ListKubeLabs(ctx context.Context, _ *empty.Empty) (*pb.KubeLabs, error) {
+	pbKl := map[string]*pb.KubeLab{}
+
+	for k, v := range s.scheduler.KubeLabs {
+		pbKl[k] = v.ToProtoKubeLab()
+	}
+
+	return &pb.KubeLabs{
+		Items: pbKl,
+	}, nil
+}
+
+func (s *server) GetKubeLab(ctx context.Context, uuid *pb.KubeLabUuid) (*pb.KubeLab, error) {
+	if _, ok := s.scheduler.KubeLabs[uuid.Id]; !ok {
+		return nil, fmt.Errorf("Kubelab %s not found", uuid.Id)
+	}
+	return s.scheduler.KubeLabs[uuid.Id].ToProtoKubeLab(), nil
+}

--- a/api/exp/lessondefs.go
+++ b/api/exp/lessondefs.go
@@ -22,10 +22,6 @@ func (s *server) ListLessonDefs(ctx context.Context, filter *pb.LessonDefFilter)
 	// TODO(mierdin): Okay for now, but not super efficient. Should store in category keys when loaded.
 	for _, lessonDef := range s.scheduler.LessonDefs {
 
-		for s := range lessonDef.Stages {
-			lessonDef.Stages[s].LabGuide = ""
-		}
-
 		if filter.Category == "" {
 			defs = append(defs, lessonDef)
 			continue

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -46,7 +46,7 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 	// stage ID 1 refers to the second index (1) in the stage slice.
 	// So, to check that the requested stage exists, the length of the slice must be equal or greater than the
 	// requested stage + 1. I.e. if there's only one stage, the slice will have a length of 2
-	if len(s.scheduler.LessonDefs[lp.LessonId].Stages) < int(lp.LessonStage+1) {
+	if len(s.scheduler.LessonDefs[lp.LessonId].Stages) < int(lp.LessonStage) {
 		msg := "Invalid stage ID for this lesson"
 		log.Error(msg)
 		return nil, errors.New(msg)
@@ -69,11 +69,7 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 				Uuid:      lessonUuid,
 			}
 
-			log.Debug("POOP8")
-
 			s.scheduler.Requests <- req
-
-			log.Debug("POOP9")
 
 			s.recordRequestTSDB(req)
 
@@ -81,9 +77,7 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 
 			// Nothing to do but the user did interact with this lesson so we should boop it.
 			req := &scheduler.LessonScheduleRequest{
-				LessonDef: s.scheduler.LessonDefs[lp.LessonId],
 				Operation: scheduler.OperationType_BOOP,
-				Stage:     0,
 				Uuid:      lessonUuid,
 			}
 

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -69,7 +69,11 @@ func (s *server) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*p
 				Uuid:      lessonUuid,
 			}
 
+			log.Debug("POOP8")
+
 			s.scheduler.Requests <- req
+
+			log.Debug("POOP9")
 
 			s.recordRequestTSDB(req)
 

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -201,7 +201,16 @@ func (s *server) ListLiveLessons(ctx context.Context, _ *empty.Empty) (*pb.LiveL
 
 func (s *server) KillLiveLesson(ctx context.Context, uuid *pb.LessonUUID) (*pb.KillLiveLessonStatus, error) {
 
-	// Should add a request to the kubelab here too so it gets cleaned up there, just like you need to do with GC.
+	if _, ok := s.liveLessonState[uuid.Id]; !ok {
+		return nil, errors.New("Livelesson not found")
+	}
+
+	s.scheduler.Requests <- &scheduler.LessonScheduleRequest{
+		Operation: scheduler.OperationType_DELETE,
+		Uuid:      uuid.Id,
+	}
+
+	return &pb.KillLiveLessonStatus{Success: true}, nil
 }
 
 func (s *server) RequestVerification(ctx context.Context, uuid *pb.LessonUUID) (*pb.VerificationTaskUUID, error) {

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -194,3 +194,12 @@ func (s *server) GetGCWhitelist(ctx context.Context, _ *empty.Empty) (*pb.Sessio
 		Sessions: sessions,
 	}, nil
 }
+
+func (s *server) ListLiveLessons(ctx context.Context, _ *empty.Empty) (*pb.LiveLessons, error) {
+	return &pb.LiveLessons{Items: s.liveLessonState}, nil
+}
+
+func (s *server) KillLiveLesson(ctx context.Context, uuid *pb.LessonUUID) (*pb.KillLiveLessonStatus, error) {
+
+	// Should add a request to the kubelab here too so it gets cleaned up there, just like you need to do with GC.
+}

--- a/api/exp/resulthandlers.go
+++ b/api/exp/resulthandlers.go
@@ -1,5 +1,67 @@
 package api
 
-func (s *server) HandleResponseCREATE() {
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+	scheduler "github.com/nre-learning/syringe/scheduler"
+	log "github.com/sirupsen/logrus"
+)
+
+func (s *server) handleResponseCREATE(result *scheduler.LessonScheduleResult) {
+	if !result.Success {
+		log.Errorf("Problem encountered in request %s: %s", result.Uuid, result.Message)
+		s.SetLiveLesson(result.Uuid, &pb.LiveLesson{Error: true})
+		return
+	}
+
+	s.recordProvisioningTime(result.ProvisioningTime, result)
+	s.SetLiveLesson(result.Uuid, s.scheduler.KubeLabs[result.Uuid].ToLiveLesson())
+}
+
+func (s *server) handleResponseMODIFY(result *scheduler.LessonScheduleResult) {
+	if !result.Success {
+		log.Errorf("Problem encountered in request %s: %s", result.Uuid, result.Message)
+		s.SetLiveLesson(result.Uuid, &pb.LiveLesson{Error: true})
+		return
+	}
+	s.SetLiveLesson(result.Uuid, s.scheduler.KubeLabs[result.Uuid].ToLiveLesson())
+}
+
+func (s *server) handleResponseVERIFY(result *scheduler.LessonScheduleResult) {
+	vtUUID := fmt.Sprintf("%s-%d", result.Uuid, result.Stage)
+
+	vt := s.verificationTasks[vtUUID]
+	vt.Working = false
+	vt.Success = result.Success
+	if result.Success == true {
+		vt.Message = "Successfully verified"
+	} else {
+
+		// TODO(mierdin): Provide an optional field for the author to provide a hint that overrides this.
+		vt.Message = "Failed to verify"
+	}
+	vt.Completed = &timestamp.Timestamp{
+		Seconds: time.Now().Unix(),
+	}
+
+	s.SetVerificationTask(vtUUID, vt)
 
 }
+
+func (s *server) handleResponseDELETE(result *scheduler.LessonScheduleResult) {
+	// This is a bit awkward. Maybe change UUID to a slice? Then just act on all?
+	if len(result.GCLessons) > 0 {
+		for i := range result.GCLessons {
+			uuid := strings.TrimRight(result.GCLessons[i], "-ns")
+			s.DeleteLiveLesson(uuid)
+		}
+	} else {
+		s.DeleteLiveLesson(result.Uuid)
+	}
+}
+
+func (s *server) handleResponseBOOP(result *scheduler.LessonScheduleResult) {}

--- a/api/exp/resulthandlers.go
+++ b/api/exp/resulthandlers.go
@@ -1,0 +1,5 @@
+package api
+
+func (s *server) HandleResponseCREATE() {
+
+}

--- a/api/exp/server.go
+++ b/api/exp/server.go
@@ -159,7 +159,7 @@ func StartAPI(ls *scheduler.LessonScheduler, grpcPort, httpPort int, buildInfo m
 				apiServer.SetLiveLesson(result.Uuid, apiServer.scheduler.KubeLabs[result.Uuid].ToLiveLesson())
 			} else if result.Operation == scheduler.OperationType_MODIFY {
 				apiServer.SetLiveLesson(result.Uuid, apiServer.scheduler.KubeLabs[result.Uuid].ToLiveLesson())
-			} else if result.Operation == scheduler.OperationType_GC {
+			} else if result.Operation == scheduler.OperationType_DELETE {
 				for i := range result.GCLessons {
 					uuid := strings.TrimRight(result.GCLessons[i], "-ns")
 					apiServer.DeleteLiveLesson(uuid)

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -411,6 +411,15 @@ Livelesson = `{
     "expHealthCheckMessage": {
       "type": "object"
     },
+    "expKillLiveLessonStatus": {
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "format": "boolean"
+        }
+      }
+    },
     "expLessonParams": {
       "type": "object",
       "properties": {
@@ -507,6 +516,17 @@ Livelesson = `{
         }
       },
       "description": "A provisioned lab without the scheduler details. The server will translate from an underlying type\n(i.e. KubeLab) into this, so only the abstract, relevant details are presented."
+    },
+    "expLiveLessons": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/expLiveLesson"
+          }
+        }
+      }
     },
     "expSession": {
       "type": "object",

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -1,6 +1,314 @@
 package swagger 
 
 const (
+Kubelab = `{
+  "swagger": "2.0",
+  "info": {
+    "title": "kubelab.proto",
+    "version": "version not set"
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "expBlackbox": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "Ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "expConnection": {
+      "type": "object",
+      "properties": {
+        "A": {
+          "type": "string"
+        },
+        "B": {
+          "type": "string"
+        },
+        "Subnet": {
+          "type": "string"
+        }
+      }
+    },
+    "expDevice": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "Ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "expIframeResource": {
+      "type": "object",
+      "properties": {
+        "Ref": {
+          "type": "string"
+        },
+        "Protocol": {
+          "type": "string"
+        },
+        "Path": {
+          "type": "string"
+        },
+        "Port": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "expKubeLab": {
+      "type": "object",
+      "properties": {
+        "Namespace": {
+          "type": "string"
+        },
+        "CreateRequest": {
+          "$ref": "#/definitions/expLessonScheduleRequest"
+        },
+        "Networks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Pods": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Services": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Ingresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/expStatus"
+        },
+        "ReachableEndpoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "CurrentStage": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "expKubeLabs": {
+      "type": "object",
+      "properties": {
+        "Items": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/expKubeLab"
+          }
+        }
+      }
+    },
+    "expLessonDef": {
+      "type": "object",
+      "properties": {
+        "LessonId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Stages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expLessonStage"
+          }
+        },
+        "LessonName": {
+          "type": "string"
+        },
+        "IframeResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expIframeResource"
+          }
+        },
+        "Devices": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expDevice"
+          }
+        },
+        "Utilities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expUtility"
+          }
+        },
+        "Blackboxes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expBlackbox"
+          }
+        },
+        "Connections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expConnection"
+          }
+        },
+        "Category": {
+          "type": "string"
+        },
+        "LessonDiagram": {
+          "type": "string"
+        },
+        "LessonVideo": {
+          "type": "string"
+        },
+        "Tier": {
+          "type": "string"
+        },
+        "Prereqs": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "Tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Collection": {
+          "type": "string"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "Slug": {
+          "type": "string",
+          "title": "This is meant to fill: \"How well do you know \u003cslug\u003e?\""
+        }
+      }
+    },
+    "expLessonScheduleRequest": {
+      "type": "object",
+      "properties": {
+        "LessonDef": {
+          "$ref": "#/definitions/expLessonDef"
+        },
+        "OperationType": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Uuid": {
+          "type": "string"
+        },
+        "Stage": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Created": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "expLessonStage": {
+      "type": "object",
+      "properties": {
+        "Id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Description": {
+          "type": "string"
+        },
+        "LabGuide": {
+          "type": "string"
+        },
+        "JupyterLabGuide": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "VerifyCompleteness": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "VerifyObjective": {
+          "type": "string"
+        }
+      }
+    },
+    "expStatus": {
+      "type": "string",
+      "enum": [
+        "DONOTUSE",
+        "INITIAL_BOOT",
+        "CONFIGURATION",
+        "READY"
+      ],
+      "default": "DONOTUSE"
+    },
+    "expUtility": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "Ports": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}
+`
 Lessondef = `{
   "swagger": "2.0",
   "info": {

--- a/cmd/syrctl/main.go
+++ b/cmd/syrctl/main.go
@@ -153,6 +153,53 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:    "livelesson",
+			Aliases: []string{"ll"},
+			Usage:   "syrctl livelesson <subcommand>",
+			Subcommands: []cli.Command{
+				{
+					Name:  "list",
+					Usage: "List livelessons",
+					Action: func(c *cli.Context) {
+
+						// TODO(mierdin): Add security options
+						conn, err := grpc.Dial(fmt.Sprintf("%s:%s", host, port), grpc.WithInsecure())
+						if err != nil {
+							fmt.Println(err)
+						}
+					},
+				},
+				{
+					Name:  "kill",
+					Usage: "Kill a livelesson",
+					Action: func(c *cli.Context) {
+
+						sid := c.Args().First()
+						if sid == "" {
+							fmt.Println("Please provide livelesson ID to kill")
+							os.Exit(1)
+						}
+
+						// TODO(mierdin): Add security options
+						conn, err := grpc.Dial(fmt.Sprintf("%s:%s", host, port), grpc.WithInsecure())
+						if err != nil {
+							fmt.Println(err)
+						}
+						defer conn.Close()
+						client := pb.NewLiveLessonsServiceClient(conn)
+
+						client.RemoveSessionFromGCWhitelist(context.Background(), &pb.Session{Id: sid})
+						if err != nil {
+							fmt.Println(err)
+							os.Exit(1)
+						}
+
+						fmt.Printf("Livelesson %s killed.\n", sid)
+					},
+				},
+			},
+		},
 	}
 
 	app.Run(os.Args)

--- a/cmd/syrctl/main.go
+++ b/cmd/syrctl/main.go
@@ -142,7 +142,7 @@ func main() {
 						defer conn.Close()
 						client := pb.NewLiveLessonsServiceClient(conn)
 
-						client.RemoveSessionFromGCWhitelist(context.Background(), &pb.Session{Id: sid})
+						_, err = client.RemoveSessionFromGCWhitelist(context.Background(), &pb.Session{Id: sid})
 						if err != nil {
 							fmt.Println(err)
 							os.Exit(1)
@@ -168,6 +168,20 @@ func main() {
 						if err != nil {
 							fmt.Println(err)
 						}
+						defer conn.Close()
+						client := pb.NewLiveLessonsServiceClient(conn)
+
+						liveLessons, err := client.ListLiveLessons(context.Background(), &empty.Empty{})
+						if err != nil {
+							fmt.Println(err)
+							os.Exit(1)
+						}
+
+						fmt.Println("LIVELESSONS")
+
+						for i := range liveLessons.Items {
+							fmt.Println(liveLessons.Items[i].LessonUUID)
+						}
 					},
 				},
 				{
@@ -175,8 +189,8 @@ func main() {
 					Usage: "Kill a livelesson",
 					Action: func(c *cli.Context) {
 
-						sid := c.Args().First()
-						if sid == "" {
+						uuid := c.Args().First()
+						if uuid == "" {
 							fmt.Println("Please provide livelesson ID to kill")
 							os.Exit(1)
 						}
@@ -189,13 +203,13 @@ func main() {
 						defer conn.Close()
 						client := pb.NewLiveLessonsServiceClient(conn)
 
-						client.RemoveSessionFromGCWhitelist(context.Background(), &pb.Session{Id: sid})
+						_, err = client.KillLiveLesson(context.Background(), &pb.LessonUUID{Id: uuid})
 						if err != nil {
 							fmt.Println(err)
 							os.Exit(1)
 						}
 
-						fmt.Printf("Livelesson %s killed.\n", sid)
+						fmt.Printf("Livelesson %s killed.\n", uuid)
 					},
 				},
 			},

--- a/cmd/syrctl/main.go
+++ b/cmd/syrctl/main.go
@@ -184,6 +184,35 @@ func main() {
 					},
 				},
 				{
+					Name:  "get",
+					Usage: "get a Livelesson",
+					Action: func(c *cli.Context) {
+
+						uuid := c.Args().First()
+						if uuid == "" {
+							fmt.Println("Please provide livelesson ID to get")
+							os.Exit(1)
+						}
+
+						// TODO(mierdin): Add security options
+						conn, err := grpc.Dial(fmt.Sprintf("%s:%s", host, port), grpc.WithInsecure())
+						if err != nil {
+							fmt.Println(err)
+						}
+						defer conn.Close()
+						client := pb.NewLiveLessonsServiceClient(conn)
+
+						ll, err := client.GetLiveLesson(context.Background(), &pb.LessonUUID{Id: uuid})
+						if err != nil {
+							fmt.Println(err)
+							os.Exit(1)
+						}
+
+						jpbm := jsonpb.Marshaler{}
+						fmt.Println(jpbm.MarshalToString(ll))
+					},
+				},
+				{
 					Name:  "kill",
 					Usage: "Kill a livelesson",
 					Action: func(c *cli.Context) {
@@ -263,14 +292,14 @@ func main() {
 						defer conn.Close()
 						client := pb.NewKubeLabServiceClient(conn)
 
-						kubeLabs, err := client.GetKubeLab(context.Background(), &pb.KubeLabUuid{Id: uuid})
+						kubeLab, err := client.GetKubeLab(context.Background(), &pb.KubeLabUuid{Id: uuid})
 						if err != nil {
 							fmt.Println(err)
 							os.Exit(1)
 						}
 
 						jpbm := jsonpb.Marshaler{}
-						fmt.Println(jpbm.MarshalToString(kubeLabs))
+						fmt.Println(jpbm.MarshalToString(kubeLab))
 					},
 				},
 			},

--- a/cmd/syringed/main.go
+++ b/cmd/syringed/main.go
@@ -48,7 +48,10 @@ func main() {
 		SyringeConfig: syringeConfig,
 		GcWhiteList:   make(map[string]*pb.Session),
 		GcWhiteListMu: &sync.Mutex{},
+		KubeLabs:      make(map[string]*scheduler.KubeLab),
+		KubeLabsMu:    &sync.Mutex{},
 	}
+
 	go func() {
 		err = lessonScheduler.Start()
 		if err != nil {

--- a/compile-proto.sh
+++ b/compile-proto.sh
@@ -1,0 +1,20 @@
+declare -a protos=(
+    "kubelab.proto"
+    "lessondef.proto"
+    "livelesson.proto"
+    "syringeinfo.proto"
+)
+
+for i in "${protos[@]}"
+do
+    echo "Compiling protobufs for $i..."
+    protoc -I api/exp/definitions/ -I./api/exp/definitions \
+        -I api/exp/definitions/ \
+        api/exp/definitions/"$i" \
+            -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
+            -I$GOPATH/src/github.com/lyft/protoc-gen-validate \
+        --go_out=plugins=grpc:api/exp/generated/ \
+        --grpc-gateway_out=logtostderr=true,allow_delete_body=true:api/exp/generated/ \
+        --validate_out=lang=go:api/exp/generated/ \
+        --swagger_out=logtostderr=true,allow_delete_body=true:api/exp/definitions/
+done

--- a/compile-proto.sh
+++ b/compile-proto.sh
@@ -1,9 +1,11 @@
+#!/bin/bash
+
 declare -a protos=(
-    "kubelab.proto"
-    "lessondef.proto"
-    "livelesson.proto"
-    "syringeinfo.proto"
-)
+    'kubelab.proto'
+    'lessondef.proto'
+    'livelesson.proto'
+    'syringeinfo.proto'
+);
 
 for i in "${protos[@]}"
 do

--- a/scheduler/kubelab.go
+++ b/scheduler/kubelab.go
@@ -155,8 +155,6 @@ func (kl *KubeLab) ToLiveLesson() *pb.LiveLesson {
 		ret.LiveEndpoints[endpoint.Name] = endpoint
 	}
 
-	ret.LabGuide = kl.CreateRequest.LessonDef.Stages[kl.CreateRequest.Stage].LabGuide
-
 	return &ret
 }
 

--- a/scheduler/kubelab.go
+++ b/scheduler/kubelab.go
@@ -1,0 +1,330 @@
+package scheduler
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+	crd "github.com/nre-learning/syringe/pkg/apis/k8s.cni.cncf.io/v1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+// KubeLab is the collection of kubernetes resources that makes up a lab instance
+type KubeLab struct {
+	Namespace          *corev1.Namespace
+	CreateRequest      *LessonScheduleRequest // The request that originally resulted in this KubeLab
+	Networks           map[string]*crd.NetworkAttachmentDefinition
+	Pods               map[string]*corev1.Pod
+	Services           map[string]*corev1.Service
+	Ingresses          map[string]*v1beta1.Ingress
+	Status             pb.Status
+	ReachableEndpoints []string // endpoint names
+	CurrentStage       int32
+}
+
+// ToProtoKubeLab is a converter function that transforms a native KubeLab struct instance
+// into a protobuf-based KubeLab instance. Not all fields can be modeled in protobuf, so this
+// function mostly just uses the name of Kubernetes objects in lieu of the actual object.
+func (kl *KubeLab) ToProtoKubeLab() *pb.KubeLab {
+
+	networks := []string{}
+	for k, _ := range kl.Networks {
+		networks = append(networks, k)
+	}
+
+	pods := []string{}
+	for k, _ := range kl.Pods {
+		pods = append(pods, k)
+	}
+
+	services := []string{}
+	for k, _ := range kl.Services {
+		services = append(services, k)
+	}
+
+	ingresses := []string{}
+	for k, _ := range kl.Ingresses {
+		ingresses = append(ingresses, k)
+	}
+
+	ts := &timestamp.Timestamp{
+		Seconds: kl.CreateRequest.Created.Unix(),
+	}
+
+	return &pb.KubeLab{
+		Namespace: kl.Namespace.ObjectMeta.Name,
+		CreateRequest: &pb.LessonScheduleRequest{
+			LessonDef:     kl.CreateRequest.LessonDef,
+			OperationType: int32(kl.CreateRequest.Operation),
+			Uuid:          kl.CreateRequest.Uuid,
+			Stage:         kl.CreateRequest.Stage,
+			Created:       ts,
+		},
+		Networks:           networks,
+		Pods:               pods,
+		Services:           services,
+		Ingresses:          ingresses,
+		Status:             kl.Status,
+		ReachableEndpoints: kl.ReachableEndpoints,
+		CurrentStage:       kl.CurrentStage,
+	}
+}
+
+func (kl *KubeLab) isReachable(epName string) bool {
+	for _, b := range kl.ReachableEndpoints {
+		if b == epName {
+			return true
+		}
+	}
+	return false
+}
+
+func (kl *KubeLab) setEndpointReachable(epName string) {
+	// Return if already in slice
+	if kl.isReachable(epName) {
+		return
+	}
+	kl.ReachableEndpoints = append(kl.ReachableEndpoints, epName)
+}
+
+// ToLiveLesson exports a KubeLab as a generic LiveLesson so the API can use it
+func (kl *KubeLab) ToLiveLesson() *pb.LiveLesson {
+
+	ts, _ := strconv.ParseInt(kl.Namespace.ObjectMeta.Labels["created"], 10, 64)
+
+	ret := pb.LiveLesson{
+		LessonUUID:      kl.CreateRequest.Uuid,
+		LessonId:        kl.CreateRequest.LessonDef.LessonId,
+		LiveEndpoints:   map[string]*pb.LiveEndpoint{},
+		LessonStage:     kl.CurrentStage,
+		LessonDiagram:   kl.CreateRequest.LessonDef.LessonDiagram,
+		LessonVideo:     kl.CreateRequest.LessonDef.LessonVideo,
+		LabGuide:        kl.CreateRequest.LessonDef.Stages[kl.CurrentStage].LabGuide,
+		JupyterLabGuide: kl.CreateRequest.LessonDef.Stages[kl.CurrentStage].JupyterLabGuide,
+		CreatedTime: &timestamp.Timestamp{
+			Seconds: ts,
+		},
+		LiveLessonStatus: kl.Status,
+	}
+
+	for s := range kl.Services {
+
+		// find corresponding pod for this service
+		var podBuddy *corev1.Pod
+		for p := range kl.Pods {
+			if kl.Pods[p].ObjectMeta.Name == kl.Services[s].ObjectMeta.Name {
+				podBuddy = kl.Pods[p]
+				break
+			}
+		}
+
+		// TODO(mierdin): handle if podbuddy is still empty
+
+		host, port, _ := getConnectivityInfo(kl.Services[s])
+		// portInt, _ := strconv.Atoi(port)
+
+		endpoint := &pb.LiveEndpoint{
+			Name: podBuddy.ObjectMeta.Name,
+			Type: pb.LiveEndpoint_EndpointType(pb.LiveEndpoint_EndpointType_value[podBuddy.Labels["endpointType"]]),
+			Host: host,
+			Port: int32(port),
+			// ApiPort
+		}
+
+		// Convert kubelab reachability to livelesson reachability
+		if kl.isReachable(endpoint.Name) {
+			endpoint.Reachable = true
+		}
+
+		ret.LiveEndpoints[endpoint.Name] = endpoint
+	}
+
+	for i := range kl.CreateRequest.LessonDef.IframeResources {
+
+		ifr := kl.CreateRequest.LessonDef.IframeResources[i]
+
+		endpoint := &pb.LiveEndpoint{
+			Name:       ifr.Ref,
+			Type:       pb.LiveEndpoint_IFRAME,
+			IframePath: ifr.Path,
+		}
+
+		ret.LiveEndpoints[endpoint.Name] = endpoint
+	}
+
+	ret.LabGuide = kl.CreateRequest.LessonDef.Stages[kl.CreateRequest.Stage].LabGuide
+
+	return &ret
+}
+
+func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, error) {
+
+	ns, err := ls.createNamespace(req)
+	if err != nil {
+		log.Error(err)
+	}
+
+	err = ls.syncSecret(ns.ObjectMeta.Name)
+	if err != nil {
+		log.Error("Unable to sync secret into this namespace. Ingress-based resources (like iframes) may not work.")
+	}
+
+	kl := &KubeLab{
+		Namespace:     ns,
+		CreateRequest: req,
+		Networks:      map[string]*crd.NetworkAttachmentDefinition{},
+		Pods:          map[string]*corev1.Pod{},
+		Services:      map[string]*corev1.Service{},
+		Ingresses:     map[string]*v1beta1.Ingress{},
+	}
+
+	// Create our configmap for the initContainer for cloning the antidote repo
+
+	ls.createGitConfigMap(ns.ObjectMeta.Name)
+
+	// Append black box container and create ingress for jupyter lab guide if necessary
+	if usesJupyterLabGuide(req.LessonDef) {
+		jupyterBB := &pb.Blackbox{
+			Name:  "jupyterlabguide",
+			Image: "antidotelabs/jupyter",
+			Ports: []int32{8888},
+		}
+		req.LessonDef.Blackboxes = append(req.LessonDef.Blackboxes, jupyterBB)
+
+		iframeIngress, _ := ls.createIngress(
+			ns.ObjectMeta.Name,
+			&pb.IframeResource{
+				Ref:      "jupyterlabguide",
+				Protocol: "http",
+
+				// Not needed. The front-end will append this specific path to the iframe src
+				// Path:     fmt.Sprintf("/notebooks/lesson-%d/stage%d/notebook.ipynb", req.LessonDef.LessonId, req.Stage),
+
+				Port: 8888,
+			},
+		)
+		kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress
+	}
+
+	if HasDevices(kl.CreateRequest.LessonDef) {
+
+		log.Debug("Creating devices and connections")
+
+		// Create networks from connections property
+		for c := range req.LessonDef.Connections {
+			connection := req.LessonDef.Connections[c]
+			newNet, err := ls.createNetwork(c, fmt.Sprintf("%s-%s-net", connection.A, connection.B), req, true, connection.Subnet)
+			if err != nil {
+				log.Error(err)
+			}
+
+			// log.Infof("About to add %v at index %s", &newNet, &newNet.ObjectMeta.Name)
+
+			kl.Networks[newNet.ObjectMeta.Name] = newNet
+		}
+
+		// Create pods and services for devices
+		for d := range req.LessonDef.Devices {
+
+			// Create pods from devices property
+			device := req.LessonDef.Devices[d]
+			newPod, err := ls.createPod(
+				device,
+				pb.LiveEndpoint_DEVICE,
+				getMemberNetworks(device.Name, req.LessonDef.Connections),
+				req,
+			)
+			if err != nil {
+				log.Error(err)
+			}
+			kl.Pods[newPod.ObjectMeta.Name] = newPod
+
+			// Create service for this pod
+			newSvc, err := ls.createService(
+				newPod,
+				req,
+			)
+			if err != nil {
+				log.Error(err)
+			}
+			kl.Services[newSvc.ObjectMeta.Name] = newSvc
+		}
+
+	} else {
+		log.Debug("Not creating devices and connections")
+	}
+
+	// Create pods and services for utility containers
+	for d := range req.LessonDef.Utilities {
+
+		utility := req.LessonDef.Utilities[d]
+		newPod, err := ls.createPod(
+			utility,
+			pb.LiveEndpoint_UTILITY,
+			getMemberNetworks(utility.Name, req.LessonDef.Connections),
+			req,
+		)
+		if err != nil {
+			log.Error(err)
+		}
+		kl.Pods[newPod.ObjectMeta.Name] = newPod
+
+		// Create service for this pod
+		newSvc, err := ls.createService(
+			newPod,
+			req,
+		)
+		if err != nil {
+			log.Error(err)
+		}
+		kl.Services[newSvc.ObjectMeta.Name] = newSvc
+	}
+
+	// Create pods and services for black box containers
+	for d := range req.LessonDef.Blackboxes {
+
+		blackbox := req.LessonDef.Blackboxes[d]
+		newPod, err := ls.createPod(
+			blackbox,
+			pb.LiveEndpoint_BLACKBOX,
+			getMemberNetworks(blackbox.Name, req.LessonDef.Connections),
+			req,
+		)
+		if err != nil {
+			log.Error(err)
+		}
+		kl.Pods[newPod.ObjectMeta.Name] = newPod
+
+		if len(newPod.Spec.Containers[0].Ports) > 0 {
+			// Create service for this pod
+			newSvc, err := ls.createService(
+				newPod,
+				req,
+			)
+			if err != nil {
+				log.Error(err)
+			}
+			kl.Services[newSvc.ObjectMeta.Name] = newSvc
+		}
+	}
+
+	// Create pods, services, and ingresses for iframe resources
+	for d := range req.LessonDef.IframeResources {
+
+		ifr := req.LessonDef.IframeResources[d]
+
+		// Iframe resources don't create pods/services on their own. You must define a blackbox/utility/device endpoint
+		// and then refer to that in the iframeresource definition. We're just creating an ingress here to access that endpoint.
+
+		iframeIngress, _ := ls.createIngress(
+			ns.ObjectMeta.Name,
+			ifr,
+		)
+		kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress
+
+	}
+	return kl, nil
+}

--- a/scheduler/requests.go
+++ b/scheduler/requests.go
@@ -253,7 +253,8 @@ func (ls *LessonScheduler) handleRequestBOOP(newRequest *LessonScheduleRequest) 
 func (ls *LessonScheduler) handleRequestDELETE(newRequest *LessonScheduleRequest) {
 
 	ls.deleteNamespace(fmt.Sprintf("%s-ns", newRequest.Uuid))
-	// Clean up from kubelabs as well
+
+	ls.deleteKubelab(newRequest.Uuid)
 
 	ls.Results <- &LessonScheduleResult{
 		Success:   true,

--- a/scheduler/requests.go
+++ b/scheduler/requests.go
@@ -1,0 +1,263 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+	log "github.com/sirupsen/logrus"
+)
+
+func (ls *LessonScheduler) handleRequestCREATE(newRequest *LessonScheduleRequest) {
+
+	nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
+
+	newKubeLab, err := ls.createKubeLab(newRequest)
+	if err != nil {
+		log.Errorf("Error creating lesson: %s", err)
+		ls.Results <- &LessonScheduleResult{
+			Success:   false,
+			LessonDef: newRequest.LessonDef,
+			Uuid:      "",
+			Operation: newRequest.Operation,
+		}
+	}
+
+	// INITIAL_BOOT is the default status, but sending this to the API after Kubelab creation will
+	// populate the entry in the API server with data about endpoints that it doesn't have yet.
+	log.Debugf("Kubelab creation for %s complete. Moving into INITIAL_BOOT status", newRequest.Uuid)
+	newKubeLab.Status = pb.Status_INITIAL_BOOT
+
+	// The API server is watching the kubelab map for updates, so we need to make sure we
+	// set this beforce returning our first result.
+	ls.setKubelab(newRequest.Uuid, newKubeLab)
+
+	// HUHUHHHHHHHHH?????
+	ls.Results <- &LessonScheduleResult{
+		Success:   true,
+		LessonDef: newRequest.LessonDef,
+		Uuid:      newRequest.Uuid,
+		Operation: OperationType_MODIFY,
+		Stage:     newRequest.Stage,
+	}
+
+	liveLesson := newKubeLab.ToLiveLesson()
+
+	var success = false
+	for i := 0; i < 600; i++ {
+		time.Sleep(1 * time.Second)
+
+		epr := testEndpointReachability(liveLesson)
+
+		log.Debugf("Livelesson %s health check results: %v", liveLesson.LessonUUID, epr)
+
+		// Update reachability status
+		endpointUnreachable := false
+		for epName, reachable := range epr {
+			if reachable {
+				newKubeLab.setEndpointReachable(epName)
+			} else {
+				endpointUnreachable = true
+			}
+		}
+
+		ls.Results <- &LessonScheduleResult{
+			Success:   true,
+			LessonDef: newRequest.LessonDef,
+			Uuid:      newRequest.Uuid,
+			Operation: OperationType_MODIFY,
+			Stage:     newRequest.Stage,
+		}
+
+		// Begin again if one of the endpoints isn't reachable
+		if endpointUnreachable {
+			continue
+		}
+
+		success = true
+		break
+
+	}
+
+	if !success {
+		log.Errorf("Timeout waiting for lesson %d to become reachable", newRequest.LessonDef.LessonId)
+		ls.Results <- &LessonScheduleResult{
+			Success:   false,
+			LessonDef: newRequest.LessonDef,
+			Uuid:      newRequest.Uuid,
+			Operation: newRequest.Operation,
+			Stage:     newRequest.Stage,
+		}
+		return
+	} else {
+
+		log.Debugf("Setting status for livelesson %s to CONFIGURATION", newRequest.Uuid)
+		newKubeLab.Status = pb.Status_CONFIGURATION
+
+		// Send a result back to the API
+		ls.Results <- &LessonScheduleResult{
+			Success:   true,
+			LessonDef: newRequest.LessonDef,
+			Uuid:      newRequest.Uuid,
+			Operation: OperationType_MODIFY,
+			Stage:     newRequest.Stage,
+		}
+	}
+
+	if HasDevices(newRequest.LessonDef) {
+		log.Infof("Performing configuration for new instance of lesson %d", newRequest.LessonDef.LessonId)
+		err := ls.configureStuff(nsName, liveLesson, newRequest)
+		if err != nil {
+			ls.Results <- &LessonScheduleResult{
+				Success:   false,
+				LessonDef: newRequest.LessonDef,
+				Uuid:      newRequest.Uuid,
+				Operation: newRequest.Operation,
+				Stage:     newRequest.Stage,
+			}
+		}
+	} else {
+		log.Infof("Nothing to configure in %s", newRequest.Uuid)
+	}
+
+	// Set network policy ONLY after configuration has had a chance to take place. Once this is in place,
+	// only config pods spawned by Jobs will have internet access, so if this takes place earlier, lessons
+	// won't initially come up at all.
+	ls.createNetworkPolicy(nsName)
+
+	ls.setKubelab(newRequest.Uuid, newKubeLab)
+
+	log.Debugf("Setting %s to READY", newRequest.Uuid)
+	newKubeLab.Status = pb.Status_READY
+
+	ls.Results <- &LessonScheduleResult{
+		Success:          true,
+		LessonDef:        newRequest.LessonDef,
+		Uuid:             newRequest.Uuid,
+		ProvisioningTime: int(time.Since(newRequest.Created).Seconds()),
+		Operation:        newRequest.Operation,
+		Stage:            newRequest.Stage,
+	}
+}
+
+func (ls *LessonScheduler) handleRequestMODIFY(newRequest *LessonScheduleRequest) {
+
+	nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
+
+	// TODO(mierdin): Check for presence first?
+	kl := ls.KubeLabs[newRequest.Uuid]
+	kl.CurrentStage = newRequest.Stage
+	ls.setKubelab(newRequest.Uuid, kl)
+
+	liveLesson := kl.ToLiveLesson()
+
+	if HasDevices(newRequest.LessonDef) {
+		log.Infof("Performing configuration of modified instance of lesson %d", newRequest.LessonDef.LessonId)
+		err := ls.configureStuff(nsName, liveLesson, newRequest)
+		if err != nil {
+			ls.Results <- &LessonScheduleResult{
+				Success:   false,
+				LessonDef: newRequest.LessonDef,
+				Uuid:      newRequest.Uuid,
+				Operation: newRequest.Operation,
+				Stage:     newRequest.Stage,
+			}
+			return
+		}
+	} else {
+		log.Infof("Skipping configuration of modified instance of lesson %d", newRequest.LessonDef.LessonId)
+	}
+
+	err := ls.boopNamespace(nsName)
+	if err != nil {
+		log.Errorf("Problem modify-booping %s: %v", nsName, err)
+	}
+
+	ls.Results <- &LessonScheduleResult{
+		Success:   true,
+		LessonDef: newRequest.LessonDef,
+		Uuid:      newRequest.Uuid,
+		Operation: newRequest.Operation,
+		Stage:     newRequest.Stage,
+	}
+}
+
+func (ls *LessonScheduler) handleRequestVERIFY(newRequest *LessonScheduleRequest) {
+	nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
+
+	ls.killAllJobs(nsName, "verify")
+	verifyJob, err := ls.verifyLiveLesson(newRequest)
+	if err != nil {
+		log.Debugf("Unable to verify: %s", err)
+
+		ls.Results <- &LessonScheduleResult{
+			Success:   false,
+			LessonDef: newRequest.LessonDef,
+			Uuid:      newRequest.Uuid,
+			Operation: newRequest.Operation,
+			Stage:     newRequest.Stage,
+		}
+	}
+
+	// Quick timeout here. About 30 seconds or so.
+	for i := 0; i < 15; i++ {
+
+		finished, err := ls.verifyStatus(verifyJob, newRequest)
+		// Return immediately if there was a problem
+		if err != nil {
+			ls.Results <- &LessonScheduleResult{
+				Success:   false,
+				LessonDef: newRequest.LessonDef,
+				Uuid:      newRequest.Uuid,
+				Operation: newRequest.Operation,
+				Stage:     newRequest.Stage,
+			}
+			return
+		}
+
+		// Return immediately if successful and finished
+		if finished == true {
+			ls.Results <- &LessonScheduleResult{
+				Success:   true,
+				LessonDef: newRequest.LessonDef,
+				Uuid:      newRequest.Uuid,
+				Operation: newRequest.Operation,
+				Stage:     newRequest.Stage,
+			}
+			return
+		}
+
+		// Not failed or succeeded yet. Try again.
+		time.Sleep(2 * time.Second)
+	}
+
+	// Return failure, there's clearly a problem.
+	ls.Results <- &LessonScheduleResult{
+		Success:   false,
+		LessonDef: newRequest.LessonDef,
+		Uuid:      newRequest.Uuid,
+		Operation: newRequest.Operation,
+		Stage:     newRequest.Stage,
+	}
+}
+
+func (ls *LessonScheduler) handleRequestBOOP(newRequest *LessonScheduleRequest) {
+	nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
+
+	err := ls.boopNamespace(nsName)
+	if err != nil {
+		log.Errorf("Problem booping %s: %v", nsName, err)
+	}
+}
+
+func (ls *LessonScheduler) handleRequestDELETE(newRequest *LessonScheduleRequest) {
+
+	ls.deleteNamespace(fmt.Sprintf("%s-ns", newRequest.Uuid))
+	// Clean up from kubelabs as well
+
+	ls.Results <- &LessonScheduleResult{
+		Success:   true,
+		Uuid:      newRequest.Uuid,
+		Operation: newRequest.Operation,
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -38,25 +38,6 @@ type Endpoint interface {
 	GetPorts() []int32
 }
 
-type LessonScheduleRequest struct {
-	LessonDef *pb.LessonDef
-	Operation OperationType
-	Uuid      string
-	Stage     int32
-	Created   time.Time
-}
-
-type LessonScheduleResult struct {
-	Success          bool
-	Stage            int32
-	LessonDef        *pb.LessonDef
-	Operation        OperationType
-	Message          string
-	ProvisioningTime int
-	Uuid             string
-	GCLessons        []string
-}
-
 type LessonScheduler struct {
 	KubeConfig    *rest.Config
 	Requests      chan *LessonScheduleRequest
@@ -132,15 +113,11 @@ func (ls *LessonScheduler) Start() error {
 func (ls *LessonScheduler) setKubelab(uuid string, kl *KubeLab) {
 	ls.KubeLabsMu.Lock()
 	defer ls.KubeLabsMu.Unlock()
-	// if _, ok := ls.KubeLabs[uuid]; ok {
-	// 	return nil, fmt.Errorf("uuid %s already present in kubelab", session.Id)
-	// }
 	ls.KubeLabs[uuid] = kl
 }
 
 func (ls *LessonScheduler) deleteKubelab(uuid string) {
 	if _, ok := ls.KubeLabs[uuid]; !ok {
-		// Nothing to do
 		return
 	}
 	ls.KubeLabsMu.Lock()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -9,14 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/nre-learning/syringe/api/exp/generated"
 	config "github.com/nre-learning/syringe/config"
-	crd "github.com/nre-learning/syringe/pkg/apis/k8s.cni.cncf.io/v1"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -27,12 +24,12 @@ type OperationType int32
 
 var (
 	OperationType_CREATE OperationType = 0
-	OperationType_MODIFY OperationType = 1
-	OperationType_BOOP   OperationType = 2
-	OperationType_GC     OperationType = 3
-	OperationType_VERIFY OperationType = 4
+	OperationType_DELETE OperationType = 1
+	OperationType_MODIFY OperationType = 2
+	OperationType_BOOP   OperationType = 3
+	OperationType_GC     OperationType = 4
+	OperationType_VERIFY OperationType = 5
 	defaultGitFileMode   int32         = 0755
-	kubeLabs                           = map[string]*KubeLab{}
 )
 
 // Endpoint should be satisfied by Utility, Blackbox, and Device
@@ -56,7 +53,6 @@ type LessonScheduleResult struct {
 	LessonDef        *pb.LessonDef
 	Operation        OperationType
 	Message          string
-	KubeLab          *KubeLab
 	ProvisioningTime int
 	Uuid             string
 	GCLessons        []string
@@ -70,6 +66,8 @@ type LessonScheduler struct {
 	SyringeConfig *config.SyringeConfig
 	GcWhiteList   map[string]*pb.Session
 	GcWhiteListMu *sync.Mutex
+	KubeLabs      map[string]*KubeLab
+	KubeLabsMu    *sync.Mutex
 }
 
 // Start is meant to be run as a goroutine. The "requests" channel will wait for new requests, attempt to schedule them,
@@ -97,7 +95,6 @@ func (ls *LessonScheduler) Start() error {
 				ls.Results <- &LessonScheduleResult{
 					Success:   true,
 					LessonDef: nil,
-					KubeLab:   nil,
 					Uuid:      "",
 					Operation: OperationType_GC,
 					GCLessons: cleaned,
@@ -112,259 +109,35 @@ func (ls *LessonScheduler) Start() error {
 	// Handle incoming requests asynchronously
 	for {
 		newRequest := <-ls.Requests
-		go ls.handleRequest(newRequest)
 
 		log.WithFields(log.Fields{
 			"Operation": newRequest.Operation,
 			"Uuid":      newRequest.Uuid,
 			"Stage":     newRequest.Stage,
-		}).Debug("Scheduler received new request.")
-	}
+		}).Debug("Scheduler received new request. Sending to handle function.")
 
-	return nil
+		go func() {
+			var handlers = map[OperationType]interface{}{
+				OperationType_CREATE: ls.handleRequestCREATE,
+				OperationType_DELETE: ls.handleRequestDELETE,
+				OperationType_MODIFY: ls.handleRequestMODIFY,
+				OperationType_BOOP:   ls.handleRequestBOOP,
+				OperationType_VERIFY: ls.handleRequestVERIFY,
+			}
+			handlers[newRequest.Operation].(func(*LessonScheduleRequest))(newRequest)
+		}()
+
+		return nil
+	}
 }
 
-func (ls *LessonScheduler) handleRequest(newRequest *LessonScheduleRequest) {
-
-	nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
-
-	if newRequest.Operation == OperationType_CREATE {
-		newKubeLab, err := ls.createKubeLab(newRequest)
-		if err != nil {
-			log.Errorf("Error creating lesson: %s", err)
-			ls.Results <- &LessonScheduleResult{
-				Success:   false,
-				LessonDef: newRequest.LessonDef,
-				KubeLab:   nil,
-				Uuid:      "",
-				Operation: newRequest.Operation,
-			}
-		}
-
-		// INITIAL_BOOT is the default status, but sending this to the API after Kubelab creation will
-		// populate the entry in the API server with data about endpoints that it doesn't have yet.
-		log.Debugf("Kubelab creation for %s complete. Moving into INITIAL_BOOT status", newRequest.Uuid)
-		newKubeLab.Status = pb.Status_INITIAL_BOOT
-		ls.Results <- &LessonScheduleResult{
-			Success:   true,
-			LessonDef: newRequest.LessonDef,
-			KubeLab:   newKubeLab,
-			Uuid:      newRequest.Uuid,
-			Operation: OperationType_MODIFY,
-			Stage:     newRequest.Stage,
-		}
-
-		liveLesson := newKubeLab.ToLiveLesson()
-
-		var success = false
-		for i := 0; i < 600; i++ {
-			time.Sleep(1 * time.Second)
-
-			epr := testEndpointReachability(liveLesson)
-
-			log.Debugf("Livelesson %s health check results: %v", liveLesson.LessonUUID, epr)
-
-			// Update reachability status
-			endpointUnreachable := false
-			for epName, reachable := range epr {
-				if reachable {
-					newKubeLab.setEndpointReachable(epName)
-				} else {
-					endpointUnreachable = true
-				}
-			}
-
-			ls.Results <- &LessonScheduleResult{
-				Success:   true,
-				LessonDef: newRequest.LessonDef,
-				KubeLab:   newKubeLab,
-				Uuid:      newRequest.Uuid,
-				Operation: OperationType_MODIFY,
-				Stage:     newRequest.Stage,
-			}
-
-			// Begin again if one of the endpoints isn't reachable
-			if endpointUnreachable {
-				continue
-			}
-
-			success = true
-			break
-
-		}
-
-		if !success {
-			log.Errorf("Timeout waiting for lesson %d to become reachable", newRequest.LessonDef.LessonId)
-			ls.Results <- &LessonScheduleResult{
-				Success:   false,
-				LessonDef: newRequest.LessonDef,
-				KubeLab:   newKubeLab,
-				Uuid:      newRequest.Uuid,
-				Operation: newRequest.Operation,
-				Stage:     newRequest.Stage,
-			}
-			return
-		} else {
-
-			log.Debugf("Setting status for livelesson %s to CONFIGURATION", newRequest.Uuid)
-			newKubeLab.Status = pb.Status_CONFIGURATION
-
-			// Send a result back to the API
-			ls.Results <- &LessonScheduleResult{
-				Success:   true,
-				LessonDef: newRequest.LessonDef,
-				KubeLab:   newKubeLab,
-				Uuid:      newRequest.Uuid,
-				Operation: OperationType_MODIFY,
-				Stage:     newRequest.Stage,
-			}
-		}
-
-		if HasDevices(newRequest.LessonDef) {
-			log.Infof("Performing configuration for new instance of lesson %d", newRequest.LessonDef.LessonId)
-			err := ls.configureStuff(nsName, liveLesson, newRequest)
-			if err != nil {
-				ls.Results <- &LessonScheduleResult{
-					Success:   false,
-					LessonDef: newRequest.LessonDef,
-					KubeLab:   kubeLabs[newRequest.Uuid],
-					Uuid:      newRequest.Uuid,
-					Operation: newRequest.Operation,
-					Stage:     newRequest.Stage,
-				}
-			}
-		} else {
-			log.Infof("Nothing to configure in %s", newRequest.Uuid)
-		}
-
-		// Set network policy ONLY after configuration has had a chance to take place. Once this is in place,
-		// only config pods spawned by Jobs will have internet access, so if this takes place earlier, lessons
-		// won't initially come up at all.
-		ls.createNetworkPolicy(nsName)
-
-		kubeLabs[newRequest.Uuid] = newKubeLab
-
-		log.Debugf("Setting %s to READY", newRequest.Uuid)
-		newKubeLab.Status = pb.Status_READY
-
-		ls.Results <- &LessonScheduleResult{
-			Success:          true,
-			LessonDef:        newRequest.LessonDef,
-			KubeLab:          newKubeLab,
-			Uuid:             newRequest.Uuid,
-			ProvisioningTime: int(time.Since(newRequest.Created).Seconds()),
-			Operation:        newRequest.Operation,
-			Stage:            newRequest.Stage,
-		}
-	} else if newRequest.Operation == OperationType_MODIFY {
-
-		kubeLabs[newRequest.Uuid].CreateRequest = newRequest
-		liveLesson := kubeLabs[newRequest.Uuid].ToLiveLesson()
-
-		if HasDevices(newRequest.LessonDef) {
-			log.Infof("Performing configuration of modified instance of lesson %d", newRequest.LessonDef.LessonId)
-			err := ls.configureStuff(nsName, liveLesson, newRequest)
-			if err != nil {
-				ls.Results <- &LessonScheduleResult{
-					Success:   false,
-					LessonDef: newRequest.LessonDef,
-					KubeLab:   kubeLabs[newRequest.Uuid],
-					Uuid:      newRequest.Uuid,
-					Operation: newRequest.Operation,
-					Stage:     newRequest.Stage,
-				}
-				return
-			}
-		} else {
-			log.Infof("Skipping configuration of modified instance of lesson %d", newRequest.LessonDef.LessonId)
-		}
-
-		nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
-
-		err := ls.boopNamespace(nsName)
-		if err != nil {
-			log.Errorf("Problem modify-booping %s: %v", nsName, err)
-		}
-
-		ls.Results <- &LessonScheduleResult{
-			Success:   true,
-			LessonDef: newRequest.LessonDef,
-			KubeLab:   kubeLabs[newRequest.Uuid],
-			Uuid:      newRequest.Uuid,
-			Operation: newRequest.Operation,
-			Stage:     newRequest.Stage,
-		}
-
-	} else if newRequest.Operation == OperationType_BOOP {
-		nsName := fmt.Sprintf("%s-ns", newRequest.Uuid)
-
-		err := ls.boopNamespace(nsName)
-		if err != nil {
-			log.Errorf("Problem booping %s: %v", nsName, err)
-		}
-	} else if newRequest.Operation == OperationType_VERIFY {
-		ls.killAllJobs(nsName, "verify")
-		verifyJob, err := ls.verifyLiveLesson(newRequest)
-		if err != nil {
-			log.Debugf("Unable to verify: %s", err)
-
-			ls.Results <- &LessonScheduleResult{
-				Success:   false,
-				LessonDef: newRequest.LessonDef,
-				KubeLab:   kubeLabs[newRequest.Uuid],
-				Uuid:      newRequest.Uuid,
-				Operation: newRequest.Operation,
-				Stage:     newRequest.Stage,
-			}
-		}
-
-		// Quick timeout here. About 30 seconds or so.
-		for i := 0; i < 15; i++ {
-
-			finished, err := ls.verifyStatus(verifyJob, newRequest)
-			// Return immediately if there was a problem
-			if err != nil {
-				ls.Results <- &LessonScheduleResult{
-					Success:   false,
-					LessonDef: newRequest.LessonDef,
-					KubeLab:   kubeLabs[newRequest.Uuid],
-					Uuid:      newRequest.Uuid,
-					Operation: newRequest.Operation,
-					Stage:     newRequest.Stage,
-				}
-				return
-			}
-
-			// Return immediately if successful and finished
-			if finished == true {
-				ls.Results <- &LessonScheduleResult{
-					Success:   true,
-					LessonDef: newRequest.LessonDef,
-					KubeLab:   kubeLabs[newRequest.Uuid],
-					Uuid:      newRequest.Uuid,
-					Operation: newRequest.Operation,
-					Stage:     newRequest.Stage,
-				}
-				return
-			}
-
-			// Not failed or succeeded yet. Try again.
-			time.Sleep(2 * time.Second)
-		}
-
-		// Return failure, there's clearly a problem.
-		ls.Results <- &LessonScheduleResult{
-			Success:   false,
-			LessonDef: newRequest.LessonDef,
-			KubeLab:   kubeLabs[newRequest.Uuid],
-			Uuid:      newRequest.Uuid,
-			Operation: newRequest.Operation,
-			Stage:     newRequest.Stage,
-		}
-
-	}
-
-	log.Debug("Result sent. Now waiting for next schedule request...")
+func (ls *LessonScheduler) setKubelab(uuid string, kl *KubeLab) {
+	ls.KubeLabsMu.Lock()
+	defer ls.KubeLabsMu.Unlock()
+	// if _, ok := ls.KubeLabs[uuid]; ok {
+	// 	return nil, fmt.Errorf("uuid %s already present in kubelab", session.Id)
+	// }
+	ls.KubeLabs[uuid] = kl
 }
 
 func (ls *LessonScheduler) configureStuff(nsName string, liveLesson *pb.LiveLesson, newRequest *LessonScheduleRequest) error {
@@ -424,176 +197,6 @@ func usesJupyterLabGuide(ld *pb.LessonDef) bool {
 	return false
 }
 
-func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, error) {
-
-	ns, err := ls.createNamespace(req)
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = ls.syncSecret(ns.ObjectMeta.Name)
-	if err != nil {
-		log.Error("Unable to sync secret into this namespace. Ingress-based resources (like iframes) may not work.")
-	}
-
-	kl := &KubeLab{
-		Namespace:      ns,
-		CreateRequest:  req,
-		Networks:       map[string]*crd.NetworkAttachmentDefinition{},
-		Pods:           map[string]*corev1.Pod{},
-		Services:       map[string]*corev1.Service{},
-		Ingresses:      map[string]*v1beta1.Ingress{},
-		LabConnections: map[string]string{},
-	}
-
-	// Create our configmap for the initContainer for cloning the antidote repo
-
-	ls.createGitConfigMap(ns.ObjectMeta.Name)
-
-	// Append black box container and create ingress for jupyter lab guide if necessary
-	if usesJupyterLabGuide(req.LessonDef) {
-		jupyterBB := &pb.Blackbox{
-			Name:  "jupyterlabguide",
-			Image: "antidotelabs/jupyter",
-			Ports: []int32{8888},
-		}
-		req.LessonDef.Blackboxes = append(req.LessonDef.Blackboxes, jupyterBB)
-
-		iframeIngress, _ := ls.createIngress(
-			ns.ObjectMeta.Name,
-			&pb.IframeResource{
-				Ref:      "jupyterlabguide",
-				Protocol: "http",
-
-				// Not needed. The front-end will append this specific path to the iframe src
-				// Path:     fmt.Sprintf("/notebooks/lesson-%d/stage%d/notebook.ipynb", req.LessonDef.LessonId, req.Stage),
-
-				Port: 8888,
-			},
-		)
-		kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress
-	}
-
-	if HasDevices(kl.CreateRequest.LessonDef) {
-
-		log.Debug("Creating devices and connections")
-
-		// Create networks from connections property
-		for c := range req.LessonDef.Connections {
-			connection := req.LessonDef.Connections[c]
-			newNet, err := ls.createNetwork(c, fmt.Sprintf("%s-%s-net", connection.A, connection.B), req, true, connection.Subnet)
-			if err != nil {
-				log.Error(err)
-			}
-
-			// log.Infof("About to add %v at index %s", &newNet, &newNet.ObjectMeta.Name)
-
-			kl.Networks[newNet.ObjectMeta.Name] = newNet
-		}
-
-		// Create pods and services for devices
-		for d := range req.LessonDef.Devices {
-
-			// Create pods from devices property
-			device := req.LessonDef.Devices[d]
-			newPod, err := ls.createPod(
-				device,
-				pb.LiveEndpoint_DEVICE,
-				getMemberNetworks(device.Name, req.LessonDef.Connections),
-				req,
-			)
-			if err != nil {
-				log.Error(err)
-			}
-			kl.Pods[newPod.ObjectMeta.Name] = newPod
-
-			// Create service for this pod
-			newSvc, err := ls.createService(
-				newPod,
-				req,
-			)
-			if err != nil {
-				log.Error(err)
-			}
-			kl.Services[newSvc.ObjectMeta.Name] = newSvc
-		}
-
-	} else {
-		log.Debug("Not creating devices and connections")
-	}
-
-	// Create pods and services for utility containers
-	for d := range req.LessonDef.Utilities {
-
-		utility := req.LessonDef.Utilities[d]
-		newPod, err := ls.createPod(
-			utility,
-			pb.LiveEndpoint_UTILITY,
-			getMemberNetworks(utility.Name, req.LessonDef.Connections),
-			req,
-		)
-		if err != nil {
-			log.Error(err)
-		}
-		kl.Pods[newPod.ObjectMeta.Name] = newPod
-
-		// Create service for this pod
-		newSvc, err := ls.createService(
-			newPod,
-			req,
-		)
-		if err != nil {
-			log.Error(err)
-		}
-		kl.Services[newSvc.ObjectMeta.Name] = newSvc
-	}
-
-	// Create pods and services for black box containers
-	for d := range req.LessonDef.Blackboxes {
-
-		blackbox := req.LessonDef.Blackboxes[d]
-		newPod, err := ls.createPod(
-			blackbox,
-			pb.LiveEndpoint_BLACKBOX,
-			getMemberNetworks(blackbox.Name, req.LessonDef.Connections),
-			req,
-		)
-		if err != nil {
-			log.Error(err)
-		}
-		kl.Pods[newPod.ObjectMeta.Name] = newPod
-
-		if len(newPod.Spec.Containers[0].Ports) > 0 {
-			// Create service for this pod
-			newSvc, err := ls.createService(
-				newPod,
-				req,
-			)
-			if err != nil {
-				log.Error(err)
-			}
-			kl.Services[newSvc.ObjectMeta.Name] = newSvc
-		}
-	}
-
-	// Create pods, services, and ingresses for iframe resources
-	for d := range req.LessonDef.IframeResources {
-
-		ifr := req.LessonDef.IframeResources[d]
-
-		// Iframe resources don't create pods/services on their own. You must define a blackbox/utility/device endpoint
-		// and then refer to that in the iframeresource definition. We're just creating an ingress here to access that endpoint.
-
-		iframeIngress, _ := ls.createIngress(
-			ns.ObjectMeta.Name,
-			ifr,
-		)
-		kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress
-
-	}
-	return kl, nil
-}
-
 func getConnectivityInfo(svc *corev1.Service) (string, int, error) {
 
 	var host string
@@ -615,106 +218,6 @@ func getConnectivityInfo(svc *corev1.Service) (string, int, error) {
 		return host, int(svc.Spec.Ports[0].Port), nil
 	}
 
-}
-
-// KubeLab is the collection of kubernetes resources that makes up a lab instance
-type KubeLab struct {
-	Namespace          *corev1.Namespace
-	CreateRequest      *LessonScheduleRequest // The request that originally resulted in this KubeLab
-	Networks           map[string]*crd.NetworkAttachmentDefinition
-	Pods               map[string]*corev1.Pod
-	Services           map[string]*corev1.Service
-	Ingresses          map[string]*v1beta1.Ingress
-	LabConnections     map[string]string
-	Status             pb.Status
-	ReachableEndpoints []string // endpoint names
-}
-
-func (kl *KubeLab) isReachable(epName string) bool {
-	for _, b := range kl.ReachableEndpoints {
-		if b == epName {
-			return true
-		}
-	}
-	return false
-}
-
-func (kl *KubeLab) setEndpointReachable(epName string) {
-	// Return if already in slice
-	if kl.isReachable(epName) {
-		return
-	}
-	kl.ReachableEndpoints = append(kl.ReachableEndpoints, epName)
-}
-
-// ToLiveLesson exports a KubeLab as a generic LiveLesson so the API can use it
-func (kl *KubeLab) ToLiveLesson() *pb.LiveLesson {
-
-	ts, _ := strconv.ParseInt(kl.Namespace.ObjectMeta.Labels["created"], 10, 64)
-
-	ret := pb.LiveLesson{
-		LessonUUID:      kl.CreateRequest.Uuid,
-		LessonId:        kl.CreateRequest.LessonDef.LessonId,
-		LiveEndpoints:   map[string]*pb.LiveEndpoint{},
-		LessonStage:     kl.CreateRequest.Stage,
-		LessonDiagram:   kl.CreateRequest.LessonDef.LessonDiagram,
-		LessonVideo:     kl.CreateRequest.LessonDef.LessonVideo,
-		LabGuide:        kl.CreateRequest.LessonDef.Stages[kl.CreateRequest.Stage].LabGuide,
-		JupyterLabGuide: kl.CreateRequest.LessonDef.Stages[kl.CreateRequest.Stage].JupyterLabGuide,
-		CreatedTime: &timestamp.Timestamp{
-			Seconds: ts,
-		},
-		LiveLessonStatus: kl.Status,
-	}
-
-	for s := range kl.Services {
-
-		// find corresponding pod for this service
-		var podBuddy *corev1.Pod
-		for p := range kl.Pods {
-			if kl.Pods[p].ObjectMeta.Name == kl.Services[s].ObjectMeta.Name {
-				podBuddy = kl.Pods[p]
-				break
-			}
-		}
-
-		// TODO(mierdin): handle if podbuddy is still empty
-
-		host, port, _ := getConnectivityInfo(kl.Services[s])
-		// portInt, _ := strconv.Atoi(port)
-
-		endpoint := &pb.LiveEndpoint{
-			Name: podBuddy.ObjectMeta.Name,
-			Type: pb.LiveEndpoint_EndpointType(pb.LiveEndpoint_EndpointType_value[podBuddy.Labels["endpointType"]]),
-			Host: host,
-			Port: int32(port),
-			// ApiPort
-		}
-
-		// Convert kubelab reachability to livelesson reachability
-		if kl.isReachable(endpoint.Name) {
-			endpoint.Reachable = true
-		}
-
-		ret.LiveEndpoints[endpoint.Name] = endpoint
-	}
-
-	for i := range kl.CreateRequest.LessonDef.IframeResources {
-
-		ifr := kl.CreateRequest.LessonDef.IframeResources[i]
-
-		endpoint := &pb.LiveEndpoint{
-			Name:       ifr.Ref,
-			Type:       pb.LiveEndpoint_IFRAME,
-			IframePath: ifr.Path,
-		}
-
-		ret.LiveEndpoints[endpoint.Name] = endpoint
-	}
-
-	ret.LabGuide = kl.CreateRequest.LessonDef.Stages[kl.CreateRequest.Stage].LabGuide
-
-	return &ret
 }
 
 func (ls *LessonScheduler) createGitConfigMap(nsName string) error {


### PR DESCRIPTION
> This PR got a bit out of hand - however, the actual changes are much less severe than the diff might indicate. Much of the diff was generated due to splitting code out into separate files.

The initial purpose of this PR was to add a "kill" command to be able to kill a running livelesson, details of which are below. However, in doing so, I encountered several problems with the way that state was being managed, and shared, as well as became decreasingly happy with the way the code was organized. So, in a classic case of scope creep, I started ripping things apart, and putting them back together again.

Other than the added functions for managing and exposing livelesson and kubelab state, there are not many externally-facing changes here. There are no big user-facing features in this PR. However, I believe this PR will contribute positively to the long-term stability of syringe, as well as the approachability and testability of the codebase.

A summary of changes follows:

- Formally structure things like kubelabs, request/response functions into their own files.\
- Move the kubelab map into a property of the scheduler, and add setter/deleter functions similar to livelesson functions with mutexes, so we can make changes safely in goroutines.
- Split scheduler requests/responses into their own functions. This makes them easier to manage, and also to write tests for down the road.
- Compile protobuf files separately from each other. This allows us to reference types between proto files without all of the "already defined in X" errors.
- Expose kubelab and livelesson state via grpc services No REST gateway functionality for security reasons. Add relevant "list" and "get commands to retrieve these via `syrctl`.
- Also added a `kill` command to `syrctl livelesson` so we can kill a running livelesson. Previously, we could delete the namespace directly with kubectl, but the state would remain in syringe, causing issues. This command will initiate the NS deletion from within Syringe, just like garbage collection, which also removes the in-memory state

Closes #66 and Closes #62
