### PR TITLE
Add ability to use host directory for lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Add ability to use host directory for lesson content [#75](https://github.com/nre-learning/syringe/pull/75)
 
 ## v0.3.0 - February 11, 2019
 

--- a/api/exp/definitions/lessondef.swagger.json
+++ b/api/exp/definitions/lessondef.swagger.json
@@ -21,7 +21,7 @@
         "operationId": "ListLessonDefs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonDefs"
             }
@@ -45,7 +45,7 @@
         "operationId": "GetLessonDef",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonDef"
             }
@@ -70,7 +70,7 @@
         "operationId": "GetAllLessonPrereqs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonPrereqs"
             }

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -20,7 +20,7 @@
         "operationId": "HealthCheck",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expHealthCheckMessage"
             }
@@ -37,7 +37,7 @@
         "operationId": "RequestLiveLesson",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonUUID"
             }
@@ -64,7 +64,7 @@
         "operationId": "GetLiveLesson",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLiveLesson"
             }
@@ -88,7 +88,7 @@
         "operationId": "RequestVerification",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expVerificationTaskUUID"
             }
@@ -120,7 +120,7 @@
         "operationId": "GetVerification",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expVerificationTask"
             }

--- a/api/exp/definitions/syringeinfo.swagger.json
+++ b/api/exp/definitions/syringeinfo.swagger.json
@@ -20,7 +20,7 @@
         "operationId": "GetSyringeInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expSyringeInfo"
             }

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -332,7 +332,7 @@ Lessondef = `{
         "operationId": "ListLessonDefs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonDefs"
             }
@@ -356,7 +356,7 @@ Lessondef = `{
         "operationId": "GetLessonDef",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonDef"
             }
@@ -381,7 +381,7 @@ Lessondef = `{
         "operationId": "GetAllLessonPrereqs",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonPrereqs"
             }
@@ -646,7 +646,7 @@ Livelesson = `{
         "operationId": "HealthCheck",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expHealthCheckMessage"
             }
@@ -663,7 +663,7 @@ Livelesson = `{
         "operationId": "RequestLiveLesson",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLessonUUID"
             }
@@ -690,7 +690,7 @@ Livelesson = `{
         "operationId": "GetLiveLesson",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expLiveLesson"
             }
@@ -714,7 +714,7 @@ Livelesson = `{
         "operationId": "RequestVerification",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expVerificationTaskUUID"
             }
@@ -746,7 +746,7 @@ Livelesson = `{
         "operationId": "GetVerification",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expVerificationTask"
             }
@@ -1000,7 +1000,7 @@ Syringeinfo = `{
         "operationId": "GetSyringeInfo",
         "responses": {
           "200": {
-            "description": "",
+            "description": "A successful response.",
             "schema": {
               "$ref": "#/definitions/expSyringeInfo"
             }

--- a/cmd/syringed/main.go
+++ b/cmd/syringed/main.go
@@ -59,7 +59,7 @@ func main() {
 		}
 	}()
 
-	antidoteSha, err := ioutil.ReadFile(fmt.Sprintf("%s/.git/refs/heads/%s", syringeConfig.LessonRepoDir, syringeConfig.LessonRepoBranch))
+	antidoteSha, err := ioutil.ReadFile(fmt.Sprintf("%s/.git/refs/heads/%s", syringeConfig.LessonDir, syringeConfig.LessonRepoBranch))
 	if err != nil {
 		log.Error("Encountered problem getting antidote SHA")
 		buildInfo["antidoteSha"] = "null"

--- a/config/config.go
+++ b/config/config.go
@@ -19,9 +19,10 @@ type SyringeConfig struct {
 	TSDBEnabled         bool
 	GCInterval          int
 
+	LessonsLocal     bool
 	LessonRepoRemote string
 	LessonRepoBranch string
-	LessonRepoDir    string
+	LessonDir        string
 }
 
 func LoadConfigVars() (*SyringeConfig, error) {
@@ -74,6 +75,12 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		}
 	}
 
+	lessonsLocal, err := strconv.ParseBool(os.Getenv("SYRINGE_LESSONS_LOCAL"))
+	if lessonsLocal == false || err != nil {
+		config.LessonsLocal = false
+	} else {
+		config.LessonsLocal = true
+	}
 	remote := os.Getenv("SYRINGE_LESSON_REPO_REMOTE")
 	if remote == "" {
 		config.LessonRepoRemote = "https://github.com/nre-learning/antidote.git"
@@ -88,11 +95,11 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.LessonRepoBranch = branch
 	}
 
-	dir := os.Getenv("SYRINGE_LESSON_REPO_DIR")
+	dir := os.Getenv("SYRINGE_LESSON_DIR")
 	if dir == "" {
-		config.LessonRepoDir = "/antidote"
+		config.LessonDir = "/antidote"
 	} else {
-		config.LessonRepoDir = dir
+		config.LessonDir = dir
 	}
 
 	gc, err := strconv.Atoi(os.Getenv("SYRINGE_GC_INTERVAL"))

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -183,14 +183,17 @@ func (ls *LessonScheduler) getVolumesConfiguration() ([]corev1.Volume, []corev1.
 		// Init container will mount the host directory as read-only, and copy entire contents into an emptyDir volume
 		initContainers = append(initContainers, corev1.Container{
 			Name:  "copy-local-files",
-			Image: "busybox",
+			Image: "bash",
 			Command: []string{
 				"cp",
 			},
 			Args: []string{
 				"-r",
-				fmt.Sprintf("%s-ro/*", ls.SyringeConfig.LessonDir),
-				ls.SyringeConfig.LessonDir,
+				"/antidote-ro/lessons/",
+				"/antidote",
+				// "-r",
+				// fmt.Sprintf("%s-ro/*", ls.SyringeConfig.LessonDir),
+				// ls.SyringeConfig.LessonDir,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -250,21 +250,13 @@ func (ls *LessonScheduler) getVolumesConfiguration() ([]corev1.Volume, []corev1.
 
 		initContainers = append(initContainers, corev1.Container{
 			Name:  "git-clone",
-			Image: "alpine/git",
-			Command: []string{
-				"/usr/local/git/git-clone.sh",
-			},
+			Image: "antidotelabs/githelper",
 			Args: []string{
 				ls.SyringeConfig.LessonRepoRemote,
 				ls.SyringeConfig.LessonRepoBranch,
 				ls.SyringeConfig.LessonDir,
 			},
 			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "git-clone",
-					ReadOnly:  false,
-					MountPath: "/usr/local/git",
-				},
 				{
 					Name:      "git-volume",
 					ReadOnly:  false,


### PR DESCRIPTION
This is in support of the functionality for selfmedicate introduced in https://github.com/nre-learning/antidote-selfmedicate/pull/8. While the production instances of Syringe will continue to use Git for pulling lesson content (so that we can use tagged versions, etc), it's useful to be able to specify that you just want to use a local directory, that some other entity will take care of mapping (in the case of selfmedicate, minikube is responsible for this).