### PR TITLE
Removed subnet requirement for lesson defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add ability to use host directory for lesson content [#75](https://github.com/nre-learning/syringe/pull/75)
 - Provide unit test framework for scheduler [#79](https://github.com/nre-learning/syringe/pull/79)
 - Clarify difference between confusing config variables [#87](https://github.com/nre-learning/syringe/pull/87)
+- Removed subnet requirement in lesson defs [#88](https://github.com/nre-learning/syringe/pull/88)
 
 ## v0.3.0 - February 11, 2019
 

--- a/api/exp/definitions/kubelab.swagger.json
+++ b/api/exp/definitions/kubelab.swagger.json
@@ -24,9 +24,6 @@
         },
         "B": {
           "type": "string"
-        },
-        "Subnet": {
-          "type": "string"
         }
       }
     },

--- a/api/exp/definitions/lessondef.proto
+++ b/api/exp/definitions/lessondef.proto
@@ -4,6 +4,7 @@ package syringe.api.exp;
 import "google/api/annotations.proto";
 // import "google/protobuf/empty.proto";
 import "validate/validate.proto";
+import "google/protobuf/descriptor.proto";
 
 service LessonDefService {
 
@@ -28,10 +29,14 @@ service LessonDefService {
 
 }
 
-// message LessonCategoryMap {
-//   map<string, LessonDefs> lessonCategories = 1;
-// }
 
+extend google.protobuf.FieldOptions {
+  Syringe syringe = 1234;
+}
+
+message Syringe {
+  string field_description = 1;
+}
 
 message LessonDefs {
   repeated LessonDef lessonDefs = 1;
@@ -107,5 +112,4 @@ message IframeResource {
 message Connection {
   string A = 1 [(validate.rules).string.min_len = 1];
   string B = 2 [(validate.rules).string.min_len = 1];
-  string Subnet = 3 [(validate.rules).string.min_len = 1];
 }

--- a/api/exp/definitions/lessondef.swagger.json
+++ b/api/exp/definitions/lessondef.swagger.json
@@ -112,9 +112,6 @@
         },
         "B": {
           "type": "string"
-        },
-        "Subnet": {
-          "type": "string"
         }
       }
     },

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -27,9 +27,6 @@ Kubelab = `{
         },
         "B": {
           "type": "string"
-        },
-        "Subnet": {
-          "type": "string"
         }
       }
     },
@@ -401,9 +398,6 @@ Lessondef = `{
           "type": "string"
         },
         "B": {
-          "type": "string"
-        },
-        "Subnet": {
           "type": "string"
         }
       }

--- a/scheduler/kubelab.go
+++ b/scheduler/kubelab.go
@@ -211,7 +211,7 @@ func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, 
 		// Create networks from connections property
 		for c := range req.LessonDef.Connections {
 			connection := req.LessonDef.Connections[c]
-			newNet, err := ls.createNetwork(c, fmt.Sprintf("%s-%s-net", connection.A, connection.B), req, true, connection.Subnet)
+			newNet, err := ls.createNetwork(c, fmt.Sprintf("%s-%s-net", connection.A, connection.B), req)
 			if err != nil {
 				log.Error(err)
 			}

--- a/scheduler/networks.go
+++ b/scheduler/networks.go
@@ -135,11 +135,9 @@ func (ls *LessonScheduler) createNetworkPolicy(nsName string) (*netv1.NetworkPol
 
 }
 
-func (ls *LessonScheduler) createNetwork(netIndex int, netName string, req *LessonScheduleRequest, deviceNetwork bool, subnet string) (*networkcrd.NetworkAttachmentDefinition, error) {
+// createNetwork
+func (ls *LessonScheduler) createNetwork(netIndex int, netName string, req *LessonScheduleRequest) (*networkcrd.NetworkAttachmentDefinition, error) {
 	nsName := fmt.Sprintf("%s-ns", req.Uuid)
-
-	// IMPORTANT - MUST set namespace before using this client.
-	// ls.ClientCrd.UpdateNamespace(nsName)
 
 	networkName := fmt.Sprintf("%s-%s", nsName, netName)
 
@@ -148,6 +146,11 @@ func (ls *LessonScheduler) createNetwork(netIndex int, netName string, req *Less
 	if len(bridgeName) > 15 {
 		bridgeName = bridgeName[0:15]
 	}
+
+	// NOTE that this is just a placeholder, not necessarily the actual subnet in use on this segment.
+	// We have to put SOMETHING here, but because we're using the bridge plugin, this isn't actually
+	// enforced, which is desired behaviors. Endpoints can still use their own subnets.
+	subnet := "10.10.0.0/16"
 
 	networkArgs := fmt.Sprintf(`{
 			"name": "%s",

--- a/scheduler/networks_test.go
+++ b/scheduler/networks_test.go
@@ -1,0 +1,80 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"testing"
+
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+	config "github.com/nre-learning/syringe/config"
+	kubernetesCrdFake "github.com/nre-learning/syringe/pkg/client/clientset/versioned/fake"
+	corev1 "k8s.io/api/core/v1"
+	kubernetesExtFake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestNetworks is responsible for ensuring Syringe-imposed networking policies are working
+func TestNetworks(t *testing.T) {
+
+	type CniDelegate struct {
+		HairpinMode bool `json:"hairpinMode,omitempty"`
+	}
+
+	type CniIpam struct {
+		IpamType string `json:"type,omitempty"`
+		Subnet   string `json:"subnet,omitempty"`
+	}
+
+	type CniNetconf struct {
+		Name         string      `json:"name,omitempty"`
+		Cnitype      string      `json:"type,omitempty"`
+		Plugin       string      `json:"plugin,omitempty"`
+		Bridge       string      `json:"bridge,omitempty"`
+		ForceAddress bool        `json:"forceAddress,omitempty"`
+		HairpinMode  bool        `json:"hairpinMode,omitempty"`
+		Delegate     CniDelegate `json:"delegate,omitempty"`
+		Ipam         CniIpam     `json:"ipam,omitempty"`
+	}
+
+	// SETUP
+	nsName := "1-foobar-ns"
+	syringeConfig := &config.SyringeConfig{
+		LessonsDir: "/antidote",
+		Domain:     "localhost",
+	}
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nsName,
+			Namespace: nsName,
+		},
+	}
+	lessonScheduler := LessonScheduler{
+		SyringeConfig: syringeConfig,
+		Client:        testclient.NewSimpleClientset(namespace),
+		ClientExt:     kubernetesExtFake.NewSimpleClientset(),
+		ClientCrd:     kubernetesCrdFake.NewSimpleClientset(),
+	}
+	uuid := "1-abcdef"
+	// END SETUP
+
+	t.Run("A=1", func(t *testing.T) {
+
+		network, err := lessonScheduler.createNetwork(
+			0,
+			"vqfx1-vqfx2",
+			&LessonScheduleRequest{
+				Uuid: uuid,
+				LessonDef: &pb.LessonDef{
+					LessonId: 1,
+				},
+			},
+		)
+		ok(t, err)
+
+		var nc CniNetconf
+		err = json.Unmarshal([]byte(network.Spec.Config), &nc)
+		ok(t, err)
+
+		assert(t, nc.Ipam.Subnet == "10.10.0.0/16", "")
+	})
+}


### PR DESCRIPTION
The `host-local` IPAM CNI plugin requires a subnet, but doesn't explicitly enforce it via filters (at least not with our current setup). So, I can remove the requirement to include a subnet in the lesson definition and just place a dummy subnet in the network configuration.

Lesson endpoints can continue to use their own addressing, this doesn't affect that functionality at all. Just simplifies lesson definitions.

I will follow up with a PR in the `antidote` repo immediately, to remove this field in all existing lesson definitions.

Closes #80 
