### PR TITLE
Setting proper permissions on copied lesson dir, using config'd location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Removed subnet requirement in lesson defs [#88](https://github.com/nre-learning/syringe/pull/88)
 - Added validation for making sure configs are present for each stage and device [#89](https://github.com/nre-learning/syringe/pull/89)
 - Add version to build info, share with syrctl [#90](https://github.com/nre-learning/syringe/pull/90)
+- Setting proper permissions on copied lesson dir, using config'd location [#92](https://github.com/nre-learning/syringe/pull/92)
 
 ## v0.3.0 - February 11, 2019
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -210,15 +210,14 @@ func (ls *LessonScheduler) getVolumesConfiguration() ([]corev1.Volume, []corev1.
 			Name:  "copy-local-files",
 			Image: "bash",
 			Command: []string{
-				"cp",
+				"bash",
 			},
 			Args: []string{
-				"-r",
-				"/antidote-ro/lessons/",
-				"/antidote",
-				// "-r",
-				// fmt.Sprintf("%s-ro/*", ls.SyringeConfig.LessonRepoDir),
-				// ls.SyringeConfig.LessonRepoDir,
+				"-c",
+				fmt.Sprintf("cp -r %s-ro/lessons/ %s && adduser -D antidote && chown -R antidote:antidote %s",
+					ls.SyringeConfig.LessonRepoDir,
+					ls.SyringeConfig.LessonRepoDir,
+					ls.SyringeConfig.LessonRepoDir),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{


### PR DESCRIPTION
For selfmedicate users, the mounted lesson directory was owned by `root:root`, which meant they couldn't make changes to lesson files, like they could in production, where Git is used to provide access to these resources.

This change recursively `chown`s the lesson directory to ensure they have this same ability when using the local copy option.