### PR TITLE
Add config flag to permit egress traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Collections Feature and API [#104](https://github.com/nre-learning/syringe/pull/104)
 - Limit volume mount to lesson directory [#109](https://github.com/nre-learning/syringe/pull/109)
 - Add configuration options to influxdb export [#108](https://github.com/nre-learning/syringe/pull/108)
+- Add config flag to permit egress traffic [#119](https://github.com/nre-learning/syringe/pull/119)
 
 ## v0.3.2 - April 19, 2019
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ type SyringeConfig struct {
 	CurriculumLocal      bool
 	CurriculumRepoRemote string
 	CurriculumRepoBranch string
+
+	AllowEgress bool
 }
 
 func (c *SyringeConfig) JSON() string {
@@ -152,6 +154,16 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.InfluxPassword = "zerocool"
 	} else {
 		config.InfluxPassword = influxPassword
+	}
+
+	// +syringeconfig SYRINGE_ALLOW_EGRESS is a boolean variable to specify if network traffic should be
+	// allowed to egress lesson namespaces. Defaults to false. If set to true, no NetworkPolicy will be created
+	// for lesson namespaces.
+	allowEgress, err := strconv.ParseBool(os.Getenv("SYRINGE_ALLOW_EGRESS"))
+	if allowEgress == false || err != nil {
+		config.AllowEgress = false
+	} else {
+		config.AllowEgress = true
 	}
 
 	log.Debugf("Syringe config: %s", config.JSON())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -66,6 +66,7 @@ func TestConfigJSON(t *testing.T) {
 		CurriculumLocal:      false,
 		CurriculumRepoRemote: "https://github.com/nre-learning/nrelabs-curriculum.git",
 		CurriculumRepoBranch: "master",
+		AllowEgress:          false,
 	}
 
 	t.Log(syringeConfig.JSON())

--- a/scheduler/requests.go
+++ b/scheduler/requests.go
@@ -161,7 +161,9 @@ func (ls *LessonScheduler) handleRequestCREATE(newRequest *LessonScheduleRequest
 	// Set network policy ONLY after configuration has had a chance to take place. Once this is in place,
 	// only config pods spawned by Jobs will have internet access, so if this takes place earlier, lessons
 	// won't initially come up at all.
-	ls.createNetworkPolicy(nsName)
+	if ls.SyringeConfig.AllowEgress {
+		ls.createNetworkPolicy(nsName)
+	}
 
 	ls.setKubelab(newRequest.Uuid, newKubeLab)
 


### PR DESCRIPTION
This adds a config flag to disable the creation of NetworkPolicies that would restrict inter-namespace traffic, including traffic to the internet. Without specifying this flag, Syringe will behave as it normally does, and will create these restrictive policies.

However, setting this flag to `true` will prevent Syringe from creating a NetworkPolicy object for lesson namespaces, which effectively results in all traffic being allowed outside of the namespace.

Closes #117