### PR TITLE
Support option to specify curriculum version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Limit volume mount to lesson directory [#109](https://github.com/nre-learning/syringe/pull/109)
 - Add configuration options to influxdb export [#108](https://github.com/nre-learning/syringe/pull/108)
 - Add config flag to permit egress traffic [#119](https://github.com/nre-learning/syringe/pull/119)
+- Support option to specify curriculum version [#120](https://github.com/nre-learning/syringe/pull/120)
 
 ## v0.3.2 - April 19, 2019
 

--- a/api/exp/lessons.go
+++ b/api/exp/lessons.go
@@ -208,6 +208,11 @@ func validateLesson(syringeConfig *config.SyringeConfig, lesson *pb.Lesson) erro
 			return fail
 		}
 
+		if strings.Contains(ep.Image, ":") {
+			log.Error("Tags are not allowed in endpoint image refs")
+			return fail
+		}
+
 		if ep.ConfigurationType == "" {
 			continue
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -111,7 +111,9 @@ func LoadConfigVars() (*SyringeConfig, error) {
 	// +syringeconfig SYRINGE_CURRICULUM_VERSION is the version of the curriculum to use.
 	version := os.Getenv("SYRINGE_CURRICULUM_VERSION")
 	if version == "" {
-		config.CurriculumVersion = "master"
+
+		// This is used to form docker image refs, so we're specifying "latest" here by default.
+		config.CurriculumVersion = "latest"
 	} else {
 		config.CurriculumVersion = version
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type SyringeConfig struct {
 	TSDBEnabled        bool
 
 	CurriculumLocal      bool
+	CurriculumVersion    string
 	CurriculumRepoRemote string
 	CurriculumRepoBranch string
 
@@ -105,6 +106,14 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.CurriculumLocal = false
 	} else {
 		config.CurriculumLocal = true
+	}
+
+	// +syringeconfig SYRINGE_CURRICULUM_VERSION is the version of the curriculum to use.
+	version := os.Getenv("SYRINGE_CURRICULUM_VERSION")
+	if version == "" {
+		config.CurriculumVersion = "master"
+	} else {
+		config.CurriculumVersion = version
 	}
 
 	// +syringeconfig SYRINGE_CURRICULUM_REPO_REMOTE is the git repo from which pull lesson content

--- a/config/config.go
+++ b/config/config.go
@@ -111,7 +111,6 @@ func LoadConfigVars() (*SyringeConfig, error) {
 	// +syringeconfig SYRINGE_CURRICULUM_VERSION is the version of the curriculum to use.
 	version := os.Getenv("SYRINGE_CURRICULUM_VERSION")
 	if version == "" {
-
 		// This is used to form docker image refs, so we're specifying "latest" here by default.
 		config.CurriculumVersion = "latest"
 	} else {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -64,6 +64,7 @@ func TestConfigJSON(t *testing.T) {
 		TSDBExportInterval:   0,
 		TSDBEnabled:          false,
 		CurriculumLocal:      false,
+		CurriculumVersion:    "latest",
 		CurriculumRepoRemote: "https://github.com/nre-learning/nrelabs-curriculum.git",
 		CurriculumRepoBranch: "master",
 		AllowEgress:          false,

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -80,7 +80,7 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 			Containers: []corev1.Container{
 				{
 					Name:  ep.GetName(),
-					Image: ep.GetImage(),
+					Image: fmt.Sprintf("%s:%s", ep.GetImage(), ls.SyringeConfig.CurriculumVersion),
 
 					// Omitting in order to keep things speedy. For debugging, uncomment this, and the image will be pulled every time.
 					ImagePullPolicy: "Always",
@@ -116,10 +116,10 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 	// Privileged status is currently required by both the lite and full vqfx versions.
 	// It may also be required by other images we bring on board.
 	privilegedImages := map[string]string{
-		"antidotelabs/vqfx:snap1":         "",
-		"antidotelabs/vqfx:snap2":         "",
-		"antidotelabs/vqfx:snap3":         "",
-		"antidotelabs/vqfx-full:18.1R1.9": "",
+		"antidotelabs/container-vqfx": "",
+		// "antidotelabs/vqfx:snap2":         "",
+		// "antidotelabs/vqfx:snap3":         "",
+		// "antidotelabs/vqfx-full:18.1R1.9": "",
 	}
 	if _, ok := privilegedImages[ep.Image]; ok {
 		b := true


### PR DESCRIPTION
Since we're now releasing the curriculum separately from the platform, we're also taking the opportunity to build and tag all curriculum images for each release. As a result, it is necessary to be able to specify which version of the curriculum Syringe is loading, so that it can be sure to request the correct tag for all endpoint versions.

This PR does this by adding an environment variable to Syringe called `SYRINGE_CURRICULUM_VERSION`, which defaults to `latest`, but in production, should be set to the exact tag used for curriculum releases, and associated curriculum image build tags.