### PR TITLE
Temporarily revert PR 120

### DIFF
--- a/api/exp/lessons.go
+++ b/api/exp/lessons.go
@@ -208,10 +208,11 @@ func validateLesson(syringeConfig *config.SyringeConfig, lesson *pb.Lesson) erro
 			return fail
 		}
 
-		if strings.Contains(ep.Image, ":") {
-			log.Error("Tags are not allowed in endpoint image refs")
-			return fail
-		}
+		// TODO(mierdin): Enable once the NRE Labs curriculum has been adjusted
+		// if strings.Contains(ep.Image, ":") {
+		// 	log.Error("Tags are not allowed in endpoint image refs")
+		// 	return fail
+		// }
 
 		if ep.ConfigurationType == "" {
 			continue

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -79,9 +79,10 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 			InitContainers: initContainers,
 			Containers: []corev1.Container{
 				{
-					Name:  ep.GetName(),
-					Image: fmt.Sprintf("%s:%s", ep.GetImage(), ls.SyringeConfig.CurriculumVersion),
-
+					Name: ep.GetName(),
+					// TODO(mierdin): Switch back the below once the NRE Labs curriculum has been adjusted
+					// Image: fmt.Sprintf("%s:%s", ep.GetImage(), ls.SyringeConfig.CurriculumVersion),
+					Image: ep.GetImage(),
 					// Omitting in order to keep things speedy. For debugging, uncomment this, and the image will be pulled every time.
 					ImagePullPolicy: "Always",
 


### PR DESCRIPTION
selfmedicate is still using the `latest` version of everything, so we'll hold off on making these image requirements for now until the curriculum has been updated to be more compatible.