### PR TITLE
Finish reverting 120

### DIFF
--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -117,10 +117,13 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 	// Privileged status is currently required by both the lite and full vqfx versions.
 	// It may also be required by other images we bring on board.
 	privilegedImages := map[string]string{
-		"antidotelabs/container-vqfx": "",
-		// "antidotelabs/vqfx:snap2":         "",
-		// "antidotelabs/vqfx:snap3":         "",
-		// "antidotelabs/vqfx-full:18.1R1.9": "",
+
+		// TODO(mierdin): Fix these once the new image is available
+		// "antidotelabs/container-vqfx":     "",
+		"antidotelabs/vqfx:snap1":         "",
+		"antidotelabs/vqfx:snap2":         "",
+		"antidotelabs/vqfx:snap3":         "",
+		"antidotelabs/vqfx-full:18.1R1.9": "",
 	}
 	if _, ok := privilegedImages[ep.Image]; ok {
 		b := true


### PR DESCRIPTION
in #121 we reverted the lesson definition restrictions implemented in #120. In this PR, we're also reverting the string slice that determines which images get privileged permissions. This should effectively finalize the back-out of #120.

In the future, a new PR will re-introduce all of this functionality, but only after a proper NRE Labs curriculum PR has been created and is ready to merge, complete with the image(s) needed to make it possible.