### PR TITLE
Enhanced granularity for image privileges and versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Limit volume mount to lesson directory [#109](https://github.com/nre-learning/syringe/pull/109)
 - Add configuration options to influxdb export [#108](https://github.com/nre-learning/syringe/pull/108)
 - Add config flag to permit egress traffic [#119](https://github.com/nre-learning/syringe/pull/119)
-- Support option to specify curriculum version [#120](https://github.com/nre-learning/syringe/pull/120)
+- Enhanced granularity for image privileges and versions [#123](https://github.com/nre-learning/syringe/pull/123)
 
 ## v0.3.2 - April 19, 2019
 

--- a/api/exp/lessons.go
+++ b/api/exp/lessons.go
@@ -208,11 +208,10 @@ func validateLesson(syringeConfig *config.SyringeConfig, lesson *pb.Lesson) erro
 			return fail
 		}
 
-		// TODO(mierdin): Enable once the NRE Labs curriculum has been adjusted
-		// if strings.Contains(ep.Image, ":") {
-		// 	log.Error("Tags are not allowed in endpoint image refs")
-		// 	return fail
-		// }
+		if strings.Contains(ep.Image, ":") {
+			log.Error("Tags are not allowed in endpoint image refs")
+			return fail
+		}
 
 		if ep.ConfigurationType == "" {
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -190,6 +190,7 @@ func LoadConfigVars() (*SyringeConfig, error) {
 			"antidotelabs/container-vqfx",
 			"antidotelabs/vqfx",
 			"antidotelabs/vqfx-full",
+			"antidotelabs/cvx",
 		}
 	} else {
 		config.PrivilegedImages = strings.Split(privImages, ",")

--- a/config/config.go
+++ b/config/config.go
@@ -188,7 +188,9 @@ func LoadConfigVars() (*SyringeConfig, error) {
 	if privImages == "" {
 		config.PrivilegedImages = []string{
 			"antidotelabs/container-vqfx",
-			"antidotelabs/vqfx",
+			"antidotelabs/vqfx-snap1",
+			"antidotelabs/vqfx-snap2",
+			"antidotelabs/vqfx-snap3",
 			"antidotelabs/vqfx-full",
 			"antidotelabs/cvx",
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,8 +69,11 @@ func TestConfigJSON(t *testing.T) {
 		CurriculumRepoBranch: "master",
 		PrivilegedImages: []string{
 			"antidotelabs/container-vqfx",
-			"antidotelabs/vqfx",
+			"antidotelabs/vqfx-snap1",
+			"antidotelabs/vqfx-snap2",
+			"antidotelabs/vqfx-snap3",
 			"antidotelabs/vqfx-full",
+			"antidotelabs/cvx",
 		},
 		AllowEgress: false,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,7 +67,12 @@ func TestConfigJSON(t *testing.T) {
 		CurriculumVersion:    "latest",
 		CurriculumRepoRemote: "https://github.com/nre-learning/nrelabs-curriculum.git",
 		CurriculumRepoBranch: "master",
-		AllowEgress:          false,
+		PrivilegedImages: []string{
+			"antidotelabs/container-vqfx",
+			"antidotelabs/vqfx",
+			"antidotelabs/vqfx-full",
+		},
+		AllowEgress: false,
 	}
 
 	t.Log(syringeConfig.JSON())

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -79,11 +79,8 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 			InitContainers: initContainers,
 			Containers: []corev1.Container{
 				{
-					Name: ep.GetName(),
-					// TODO(mierdin): Switch back the below once the NRE Labs curriculum has been adjusted
-					// Image: fmt.Sprintf("%s:%s", ep.GetImage(), ls.SyringeConfig.CurriculumVersion),
-					Image: ep.GetImage(),
-					// Omitting in order to keep things speedy. For debugging, uncomment this, and the image will be pulled every time.
+					Name:            ep.GetName(),
+					Image:           fmt.Sprintf("%s:%s", ep.GetImage(), ls.SyringeConfig.CurriculumVersion),
 					ImagePullPolicy: "Always",
 
 					// ImagePullPolicy: "IfNotPresent",
@@ -118,8 +115,7 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 	// It may also be required by other images we bring on board.
 	privilegedImages := map[string]string{
 
-		// TODO(mierdin): Fix these once the new image is available
-		// "antidotelabs/container-vqfx":     "",
+		"antidotelabs/container-vqfx":     "",
 		"antidotelabs/vqfx:snap1":         "",
 		"antidotelabs/vqfx:snap2":         "",
 		"antidotelabs/vqfx:snap3":         "",


### PR DESCRIPTION
> **NOTE** do not merge until https://github.com/nre-learning/nrelabs-curriculum/pull/248 is ready to go. This will break current `selfmedicate` users until a compatible curriculum can be delivered as well.

This PR re-introduces the changes that were originally put into place in #120 but then rolled back in #121 and #122 since the accompanying curriculum and required images weren't ready, and `selfmedicate` is currently configured to pull the `latest` syringe.

## Summary of Changes

This PR introduces the enforcement of particular curriculum image versions, since as of now, we're building and tagging all of these images for every curriculum release. It does this by prohibiting tags in image refs within a lesson definition, and appending a tag at runtime equal to the version of the curriculum that's been configured via env. If nothing is specified, `latest` is pulled for all images.

This PR also introduces the ability to configure which images are granted privileged mode. This is unfortunately  the way we currently have to do things until mini-project 6 gets off the ground. This way, however, we can maintain granularity over which images get this mode, and ensure it's limited to those that run a layer of virtualization within them (which are the only images that actually require this, or a subset of these privileges).