### PR TITLE
Fixed bug with 'allow egress' variable and added tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add configuration options to influxdb export [#108](https://github.com/nre-learning/syringe/pull/108)
 - Add config flag to permit egress traffic [#119](https://github.com/nre-learning/syringe/pull/119)
 - Enhanced granularity for image privileges and versions [#123](https://github.com/nre-learning/syringe/pull/123)
+- Fixed bug with 'allow egress' variable and added tests [#125](https://github.com/nre-learning/syringe/pull/125)
 
 ## v0.3.2 - April 19, 2019
 

--- a/cmd/syringed/main.go
+++ b/cmd/syringed/main.go
@@ -57,7 +57,7 @@ func main() {
 		GcWhiteListMu: &sync.Mutex{},
 		KubeLabs:      make(map[string]*scheduler.KubeLab),
 		KubeLabsMu:    &sync.Mutex{},
-		HealthChecker: scheduler.LessonHealthCheck{},
+		HealthChecker: &scheduler.LessonHealthCheck{},
 	}
 
 	// CREATION OF CLIENTS

--- a/scheduler/requests.go
+++ b/scheduler/requests.go
@@ -161,7 +161,7 @@ func (ls *LessonScheduler) handleRequestCREATE(newRequest *LessonScheduleRequest
 	// Set network policy ONLY after configuration has had a chance to take place. Once this is in place,
 	// only config pods spawned by Jobs will have internet access, so if this takes place earlier, lessons
 	// won't initially come up at all.
-	if ls.SyringeConfig.AllowEgress {
+	if !ls.SyringeConfig.AllowEgress {
 		ls.createNetworkPolicy(nsName)
 	}
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -62,7 +62,7 @@ type LessonScheduler struct {
 	GcWhiteListMu *sync.Mutex
 	KubeLabs      map[string]*KubeLab
 	KubeLabsMu    *sync.Mutex
-	HealthChecker LessonHealthCheck
+	HealthChecker LessonHealthChecker
 
 	// Allows us to disable GC for testing. Production code should leave this at
 	// false
@@ -158,6 +158,7 @@ func (ls *LessonScheduler) deleteKubelab(uuid string) {
 }
 
 func (ls *LessonScheduler) configureStuff(nsName string, liveLesson *pb.LiveLesson, newRequest *LessonScheduleRequest) error {
+
 	ls.killAllJobs(nsName, "config")
 
 	wg := new(sync.WaitGroup)


### PR DESCRIPTION
#119 introduced a config variable to prevent the creation of a networkpolicy to restrict network traffic outside a lesson namespace. However, I accidentally got the conditional wrong, and instead of keeping the existing behavior as the default, Syringe in its current form, by default, omits the networkpolicy, effectively allowing all traffic.

The intention was to make this an explicit opt-in, so in this PR fixes that, by simply adding the negative operator (`!`), but also adds tests to check for the presence of a networkpolicy.

> I should have done this in the first place, but the scheduler testing is still a mess, and previously the timeouts weren't getting to the point where the networkpolicy was even created. I fixed that in this PR, but there's still a lot left to do on the scheduler re: testing, hopefully to take place in a separate PR soon.