### PR TITLE
Specify version for all platform-related docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add configuration options to influxdb export [#108](https://github.com/nre-learning/syringe/pull/108)
 - Add config flag to permit egress traffic [#119](https://github.com/nre-learning/syringe/pull/119)
 - Enhanced granularity for image privileges and versions [#123](https://github.com/nre-learning/syringe/pull/123)
+- Specify version for all platform-related docker images [#126](https://github.com/nre-learning/syringe/pull/126)
 
 ## v0.3.2 - April 19, 2019
 

--- a/api/exp/definitions/syringeinfo.proto
+++ b/api/exp/definitions/syringeinfo.proto
@@ -16,6 +16,7 @@ service SyringeInfoService {
 message SyringeInfo {
   string buildSha = 1;
   string antidoteSha = 2;
+  string imageVersion = 3;
 }
 
 

--- a/api/exp/definitions/syringeinfo.swagger.json
+++ b/api/exp/definitions/syringeinfo.swagger.json
@@ -41,6 +41,9 @@
         },
         "antidoteSha": {
           "type": "string"
+        },
+        "imageVersion": {
+          "type": "string"
         }
       }
     }

--- a/api/exp/server.go
+++ b/api/exp/server.go
@@ -44,8 +44,6 @@ type SyringeAPIServer struct {
 	VerificationTasksMu *sync.Mutex
 
 	Scheduler *scheduler.LessonScheduler
-
-	BuildInfo map[string]string
 }
 
 func (apiServer *SyringeAPIServer) StartAPI(ls *scheduler.LessonScheduler, buildInfo map[string]string) error {

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -1146,6 +1146,9 @@ Syringeinfo = `{
         },
         "antidoteSha": {
           "type": "string"
+        },
+        "imageVersion": {
+          "type": "string"
         }
       }
     }

--- a/api/exp/syringeinfo.go
+++ b/api/exp/syringeinfo.go
@@ -10,17 +10,17 @@ import (
 
 func (s *SyringeAPIServer) GetSyringeInfo(ctx context.Context, _ *empty.Empty) (*pb.SyringeInfo, error) {
 
-	if _, ok := s.BuildInfo["buildSha"]; !ok {
+	if _, ok := s.Scheduler.BuildInfo["buildSha"]; !ok {
 		return &pb.SyringeInfo{}, errors.New("Build SHA not found")
 	}
 
-	if _, ok := s.BuildInfo["antidoteSha"]; !ok {
+	if _, ok := s.Scheduler.BuildInfo["antidoteSha"]; !ok {
 		return &pb.SyringeInfo{}, errors.New("Antidote SHA not found")
 	}
 
 	si := pb.SyringeInfo{
-		BuildSha:    s.BuildInfo["buildSha"],
-		AntidoteSha: s.BuildInfo["antidoteSha"],
+		BuildSha:    s.Scheduler.BuildInfo["buildSha"],
+		AntidoteSha: s.Scheduler.BuildInfo["antidoteSha"],
 	}
 
 	return &si, nil

--- a/api/exp/syringeinfo.go
+++ b/api/exp/syringeinfo.go
@@ -19,8 +19,9 @@ func (s *SyringeAPIServer) GetSyringeInfo(ctx context.Context, _ *empty.Empty) (
 	}
 
 	si := pb.SyringeInfo{
-		BuildSha:    s.Scheduler.BuildInfo["buildSha"],
-		AntidoteSha: s.Scheduler.BuildInfo["antidoteSha"],
+		BuildSha:     s.Scheduler.BuildInfo["buildSha"],
+		AntidoteSha:  s.Scheduler.BuildInfo["antidoteSha"],
+		ImageVersion: s.Scheduler.BuildInfo["imageVersion"],
 	}
 
 	return &si, nil

--- a/cmd/syringed/main.go
+++ b/cmd/syringed/main.go
@@ -58,6 +58,7 @@ func main() {
 		KubeLabs:      make(map[string]*scheduler.KubeLab),
 		KubeLabsMu:    &sync.Mutex{},
 		HealthChecker: scheduler.LessonHealthCheck{},
+		BuildInfo:     buildInfo,
 	}
 
 	// CREATION OF CLIENTS
@@ -108,7 +109,6 @@ func main() {
 		VerificationTasks:   make(map[string]*pb.VerificationTask),
 		VerificationTasksMu: &sync.Mutex{},
 		Scheduler:           &lessonScheduler,
-		BuildInfo:           buildInfo,
 	}
 	go func() {
 		err = apiServer.StartAPI(&lessonScheduler, buildInfo)

--- a/hack/gen-build-info.sh
+++ b/hack/gen-build-info.sh
@@ -1,3 +1,16 @@
+# This script is VERY important. This generates build info and places them into *.go files
+# into the source code for every build.
+#
+# When Syringe is running on a particular release, this is placed within SYRINGE_VERSION
+# and made available via the "buildVersion" key in the map shown below. This key is relied
+# upon by code within Syringe to determine the corresponding version of infrastructure Docker
+# images to call upon for things like configuration and jupyter notebooks.
+#
+# Without a way to couple the version of Syringe with the version of these important platform-related
+# docker image, these images might not work properly, resulting in the whole platform not working properly.
+#
+# Edit this script, and anything that calls it, with caution.
+
 
 SYRINGE_SHA=$(git rev-parse HEAD)
 SYRINGE_VERSION=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null)

--- a/hack/gen-build-info.sh
+++ b/hack/gen-build-info.sh
@@ -14,10 +14,12 @@
 
 SYRINGE_SHA=$(git rev-parse HEAD)
 SYRINGE_VERSION=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null)
+IMAGE_VERSION=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null)
 
 if [ -z $SYRINGE_VERSION ];
 then
 	SYRINGE_VERSION="dev-$SYRINGE_SHA"
+	IMAGE_VERSION="latest"
 fi
 
 cat <<EOT >> ./cmd/syringed/buildinfo.go
@@ -32,6 +34,7 @@ var (
 	buildInfo = map[string]string{
 		"buildSha": "$SYRINGE_SHA",
 		"buildVersion": "$SYRINGE_VERSION",
+		"imageVersion": "$IMAGE_VERSION",
 	}
 )
 
@@ -49,6 +52,7 @@ var (
 	buildInfo = map[string]string{
 		"buildSha": "$SYRINGE_SHA",
 		"buildVersion": "$SYRINGE_VERSION",
+		"imageVersion": "$IMAGE_VERSION",
 	}
 )
 

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -141,6 +141,13 @@ func (ls *LessonScheduler) configureEndpoint(ep *pb.Endpoint, req *LessonSchedul
 		return nil, errors.New("Unknown config type")
 	}
 
+	var configImageVer string
+	if strings.Contains(ls.BuildInfo["buildVersion"], "dev") {
+		configImageVer = "latest"
+	} else {
+		configImageVer = ls.BuildInfo["buildVersion"]
+	}
+
 	configJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -172,7 +179,7 @@ func (ls *LessonScheduler) configureEndpoint(ep *pb.Endpoint, req *LessonSchedul
 					Containers: []corev1.Container{
 						{
 							Name:    "configurator",
-							Image:   "antidotelabs/configurator",
+							Image:   fmt.Sprintf("antidotelabs/configurator:%s", configImageVer),
 							Command: configCommand,
 
 							// TODO(mierdin): ONLY for test/dev. Should re-evaluate for prod

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -141,13 +141,6 @@ func (ls *LessonScheduler) configureEndpoint(ep *pb.Endpoint, req *LessonSchedul
 		return nil, errors.New("Unknown config type")
 	}
 
-	var configImageVer string
-	if strings.Contains(ls.BuildInfo["buildVersion"], "dev") {
-		configImageVer = "latest"
-	} else {
-		configImageVer = ls.BuildInfo["buildVersion"]
-	}
-
 	configJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -179,7 +172,7 @@ func (ls *LessonScheduler) configureEndpoint(ep *pb.Endpoint, req *LessonSchedul
 					Containers: []corev1.Container{
 						{
 							Name:    "configurator",
-							Image:   fmt.Sprintf("antidotelabs/configurator:%s", configImageVer),
+							Image:   fmt.Sprintf("antidotelabs/configurator:%s", ls.BuildInfo["imageVersion"]),
 							Command: configCommand,
 
 							// TODO(mierdin): ONLY for test/dev. Should re-evaluate for prod

--- a/scheduler/kubelab.go
+++ b/scheduler/kubelab.go
@@ -3,7 +3,6 @@ package scheduler
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/nre-learning/syringe/api/exp/generated"
@@ -139,16 +138,10 @@ func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, 
 
 	// Append endpoint and create ingress for jupyter lab guide if necessary
 	if usesJupyterLabGuide(req.Lesson) {
-		var configImageVer string
-		if strings.Contains(ls.BuildInfo["buildVersion"], "dev") {
-			configImageVer = "latest"
-		} else {
-			configImageVer = ls.BuildInfo["buildVersion"]
-		}
 
 		jupyterEp := &pb.Endpoint{
 			Name:            "jupyterlabguide",
-			Image:           fmt.Sprintf("antidotelabs/jupyter:%s", configImageVer),
+			Image:           fmt.Sprintf("antidotelabs/jupyter:%s", ls.BuildInfo["imageVersion"]),
 			AdditionalPorts: []int32{8888},
 		}
 		req.Lesson.Endpoints = append(req.Lesson.Endpoints, jupyterEp)

--- a/scheduler/kubelab.go
+++ b/scheduler/kubelab.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/nre-learning/syringe/api/exp/generated"
@@ -138,9 +139,16 @@ func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, 
 
 	// Append endpoint and create ingress for jupyter lab guide if necessary
 	if usesJupyterLabGuide(req.Lesson) {
+		var configImageVer string
+		if strings.Contains(ls.BuildInfo["buildVersion"], "dev") {
+			configImageVer = "latest"
+		} else {
+			configImageVer = ls.BuildInfo["buildVersion"]
+		}
+
 		jupyterEp := &pb.Endpoint{
 			Name:            "jupyterlabguide",
-			Image:           "antidotelabs/jupyter:newpath",
+			Image:           fmt.Sprintf("antidotelabs/jupyter:%s", configImageVer),
 			AdditionalPorts: []int32{8888},
 		}
 		req.Lesson.Endpoints = append(req.Lesson.Endpoints, jupyterEp)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -294,16 +294,9 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 			SubPath:   lessonDir,
 		})
 
-		var configImageVer string
-		if strings.Contains(ls.BuildInfo["buildVersion"], "dev") {
-			configImageVer = "latest"
-		} else {
-			configImageVer = ls.BuildInfo["buildVersion"]
-		}
-
 		initContainers = append(initContainers, corev1.Container{
 			Name:  "git-clone",
-			Image: fmt.Sprintf("antidotelabs/githelper:%s", configImageVer),
+			Image: fmt.Sprintf("antidotelabs/githelper:%s", ls.BuildInfo["imageVersion"]),
 			Args: []string{
 				ls.SyringeConfig.CurriculumRepoRemote,
 				ls.SyringeConfig.CurriculumRepoBranch,

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -76,6 +76,8 @@ type LessonScheduler struct {
 
 	// Client for creating instances of our network CRD
 	ClientCrd kubernetesCrd.Interface
+
+	BuildInfo map[string]string
 }
 
 // Start is meant to be run as a goroutine. The "requests" channel will wait for new requests, attempt to schedule them,
@@ -291,9 +293,16 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 			SubPath:   lessonDir,
 		})
 
+		var configImageVer string
+		if strings.Contains(ls.BuildInfo["buildVersion"], "dev") {
+			configImageVer = "latest"
+		} else {
+			configImageVer = ls.BuildInfo["buildVersion"]
+		}
+
 		initContainers = append(initContainers, corev1.Container{
 			Name:  "git-clone",
-			Image: "antidotelabs/githelper",
+			Image: fmt.Sprintf("antidotelabs/githelper:%s", configImageVer),
 			Args: []string{
 				ls.SyringeConfig.CurriculumRepoRemote,
 				ls.SyringeConfig.CurriculumRepoBranch,


### PR DESCRIPTION
#120 and #122 implemented the idea of providing a curriculum version, so that specific tags/versions of the images used in a curriculum can be referenced at runtime, providing some protection against image changes. In this way, images can continue to be worked on (`latest`) without affecting the version currently in production (e.g. `v1.0.0`).

This PR provides the same functionality, but for images that fall under the "jurisdiction" of the platform, the source for which have been moved to https://github.com/nre-learning/antidote-images.

These will be automatically built and versioned, just like we're doing with curriculum images (keeping in mind that the curriculum has a totally separate release cycle as of now). The existing build info that's currently available to Syringe can now be used to determine the specific version to use when creating pods for platform-related purposes, like the `configurator`. The build workflows in https://github.com/nre-learning/antidote-ops will be augmented so that immediately after the platform components (like Syringe) are built, the platform images will be built and pushed to the corresponding tag. v0.4.0 of Syringe will use v0.4.0 of the configurator image, and so on.

Closes #124 