### PR TITLE
Opened networkpolicy to all RFC1918 for the time being

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Enhanced granularity for image privileges and versions [#123](https://github.com/nre-learning/syringe/pull/123)
 - Fixed bug with 'allow egress' variable and added tests [#125](https://github.com/nre-learning/syringe/pull/125)
 - Specify version for all platform-related docker images [#126](https://github.com/nre-learning/syringe/pull/126)
+- Opened networkpolicy to all RFC1918 for the time being [#127](https://github.com/nre-learning/syringe/pull/127)
 
 ## v0.3.2 - April 19, 2019
 

--- a/scheduler/networks.go
+++ b/scheduler/networks.go
@@ -100,9 +100,11 @@ func (ls *LessonScheduler) createNetworkPolicy(nsName string) (*netv1.NetworkPol
 					To: []netv1.NetworkPolicyPeer{
 
 						// Have only been able to get this working with this CIDR.
-						// Tried a /32 directly to the svc IP, but that didn't seem to work.
-						// Should revisit this later.
+						// Tried a /32 directly to the svc IP for DNS, but that didn't seem to work.
+						// Should revisit this later. Open to all RFC1918 for now.
 						{IPBlock: &netv1.IPBlock{CIDR: "10.0.0.0/8"}},
+						{IPBlock: &netv1.IPBlock{CIDR: "192.168.0.0/16"}},
+						{IPBlock: &netv1.IPBlock{CIDR: "171.16.0.0/12"}},
 					},
 					Ports: []netv1.NetworkPolicyPort{
 						{Protocol: &tcp, Port: &fivethree},


### PR DESCRIPTION
The new hosting provider for NRE Labs is using a 10.0.0.0/8, so we had to use a 192.168.0.0/16 for our in-cluster network. However, the networkpolicy is only allowing the former currently, which means lessons can't access cluster DNS. What's funny is that I didn't notice this until I fixed the bug in #125 and actually started applying the networkpolicy correctly.

So, this PR simply adds two more subnets to the networkpolicy, and effectively allows all RFC1918 traffic. I still want to circle back to this at some point and get more specific with the policy to only allow traffic to the specific DNS service as mentioned in the TODO, but we'll save that for another time.