### PR TITLE
Fix bug in jupyter version tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed bug with 'allow egress' variable and added tests [#125](https://github.com/nre-learning/syringe/pull/125)
 - Specify version for all platform-related docker images [#126](https://github.com/nre-learning/syringe/pull/126)
 - Opened networkpolicy to all RFC1918 for the time being [#127](https://github.com/nre-learning/syringe/pull/127)
+- Fix bug in jupyter version tagging [#128](https://github.com/nre-learning/syringe/pull/128)
 
 ## v0.3.2 - April 19, 2019
 


### PR DESCRIPTION
#126 introduced tagging images that are used for platform-related things, but the jupyter notebook server is actually spun up by slipstreaming it into the Endpoints slice, which allows it to participate in the topology. This caused it to be tagged twice, once for the platform version, and another for the curriculum version (e.g. `antidotelabs/jupyter:latest:v0.4.0`) which is invalid.

This adds a check within pods.go to only tag curriculum images in the Endpoints list, which is all excluding the jupyter image.