### PR TITLE
VERY basic "mock API" service for lightweight testing or external development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Initial work on a 'mock' syringe with static sample data for integration testing [#136])https://github.com/nre-learning/syringe/pull/136)
 - Added cvx and frr image names to privileged container list in config.go [#129](https://github.com/nre-learning/syringe/pull/129)
 - Disable TSDB by default (configurable) [#130](https://github.com/nre-learning/syringe/pull/130)
 - Cleaned up and updated deps - installing grpc tooling from source [#135](https://github.com/nre-learning/syringe/pull/135)

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ RUN cd $GOPATH/src/github.com/nre-learning/syringe && make
 # TODO(mierdin): DNS lookups not working right in scratch. I tried debian and it just blew chunks. Need to look into a solution for this
 FROM scratch
 COPY --from=build-env /go/bin/syringed /usr/bin/syringed
+COPY --from=build-env /go/bin/syringed-mock /usr/bin/syringed-mock
 COPY --from=build-env /go/bin/syrctl /usr/bin/syrctl
 CMD ["/usr/bin/syringed"]

--- a/cmd/syringed-mock/functions.go
+++ b/cmd/syringed-mock/functions.go
@@ -52,12 +52,19 @@ func (s *MockAPIServer) GetLiveLesson(ctx context.Context, uuid *pb.LessonUUID) 
 				},
 				Host: "linux1",
 			},
+			"webserver1": {
+				Name: "webserver1",
+				Presentations: []*pb.Presentation{
+					{Name: "web", Port: 80, Type: "http"},
+				},
+				Host: "webserver1",
+			},
 		},
 		LessonStage:      1,
 		LabGuide:         "foobar",
 		LiveLessonStatus: 3,
-		HealthyTests:     1,
-		TotalTests:       1,
+		HealthyTests:     2,
+		TotalTests:       2,
 	}, nil
 
 }

--- a/cmd/syringed-mock/functions.go
+++ b/cmd/syringed-mock/functions.go
@@ -10,11 +10,8 @@ import (
 // LESSON
 
 func (s *MockAPIServer) ListLessons(ctx context.Context, filter *pb.LessonFilter) (*pb.Lessons, error) {
-
-	defs := []*pb.Lesson{}
-
 	return &pb.Lessons{
-		Lessons: defs,
+		Lessons: s.Lessons,
 	}, nil
 }
 
@@ -25,7 +22,7 @@ func (s *MockAPIServer) GetAllLessonPrereqs(ctx context.Context, lid *pb.LessonI
 }
 
 func (s *MockAPIServer) GetLesson(ctx context.Context, lid *pb.LessonID) (*pb.Lesson, error) {
-	return &pb.Lesson{}, nil
+	return s.Lessons[0], nil
 }
 
 // LIVELESSON
@@ -43,7 +40,26 @@ func (s *MockAPIServer) HealthCheck(ctx context.Context, _ *empty.Empty) (*pb.He
 }
 
 func (s *MockAPIServer) GetLiveLesson(ctx context.Context, uuid *pb.LessonUUID) (*pb.LiveLesson, error) {
-	return &pb.LiveLesson{}, nil
+
+	return &pb.LiveLesson{
+		LessonUUID: "1-abcdef",
+		LessonId:   1,
+		LiveEndpoints: map[string]*pb.Endpoint{
+			"linux1": {
+				Name: "linux1",
+				Presentations: []*pb.Presentation{
+					{Name: "cli", Port: 22, Type: "ssh"},
+				},
+				Host: "linux1",
+			},
+		},
+		LessonStage:      1,
+		LabGuide:         "foobar",
+		LiveLessonStatus: 3,
+		HealthyTests:     1,
+		TotalTests:       1,
+	}, nil
+
 }
 
 func (s *MockAPIServer) AddSessiontoGCWhitelist(ctx context.Context, session *pb.Session) (*pb.HealthCheckMessage, error) {
@@ -72,4 +88,16 @@ func (s *MockAPIServer) RequestVerification(ctx context.Context, uuid *pb.Lesson
 
 func (s *MockAPIServer) GetVerification(ctx context.Context, vtUUID *pb.VerificationTaskUUID) (*pb.VerificationTask, error) {
 	return &pb.VerificationTask{}, nil
+}
+
+// COLLECTION
+
+func (s *MockAPIServer) ListCollections(ctx context.Context, filter *pb.CollectionFilter) (*pb.Collections, error) {
+	return &pb.Collections{
+		Collections: s.Collections,
+	}, nil
+}
+
+func (s *MockAPIServer) GetCollection(ctx context.Context, filter *pb.CollectionID) (*pb.Collection, error) {
+	return s.Collections[0], nil
 }

--- a/cmd/syringed-mock/functions.go
+++ b/cmd/syringed-mock/functions.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+)
+
+// LESSON
+
+func (s *MockAPIServer) ListLessons(ctx context.Context, filter *pb.LessonFilter) (*pb.Lessons, error) {
+
+	defs := []*pb.Lesson{}
+
+	return &pb.Lessons{
+		Lessons: defs,
+	}, nil
+}
+
+// var preReqs []int32
+
+func (s *MockAPIServer) GetAllLessonPrereqs(ctx context.Context, lid *pb.LessonID) (*pb.LessonPrereqs, error) {
+	return &pb.LessonPrereqs{}, nil
+}
+
+func (s *MockAPIServer) GetLesson(ctx context.Context, lid *pb.LessonID) (*pb.Lesson, error) {
+	return &pb.Lesson{}, nil
+}
+
+// LIVELESSON
+
+func (s *MockAPIServer) RequestLiveLesson(ctx context.Context, lp *pb.LessonParams) (*pb.LessonUUID, error) {
+	return &pb.LessonUUID{Id: "abcdef"}, nil
+}
+
+func (s *MockAPIServer) GetSyringeState(ctx context.Context, _ *empty.Empty) (*pb.SyringeState, error) {
+	return &pb.SyringeState{}, nil
+}
+
+func (s *MockAPIServer) HealthCheck(ctx context.Context, _ *empty.Empty) (*pb.HealthCheckMessage, error) {
+	return &pb.HealthCheckMessage{}, nil
+}
+
+func (s *MockAPIServer) GetLiveLesson(ctx context.Context, uuid *pb.LessonUUID) (*pb.LiveLesson, error) {
+	return &pb.LiveLesson{}, nil
+}
+
+func (s *MockAPIServer) AddSessiontoGCWhitelist(ctx context.Context, session *pb.Session) (*pb.HealthCheckMessage, error) {
+	return nil, nil
+}
+
+func (s *MockAPIServer) RemoveSessionFromGCWhitelist(ctx context.Context, session *pb.Session) (*pb.HealthCheckMessage, error) {
+	return nil, nil
+}
+
+func (s *MockAPIServer) GetGCWhitelist(ctx context.Context, _ *empty.Empty) (*pb.Sessions, error) {
+	return &pb.Sessions{}, nil
+}
+
+func (s *MockAPIServer) ListLiveLessons(ctx context.Context, _ *empty.Empty) (*pb.LiveLessons, error) {
+	return &pb.LiveLessons{}, nil
+}
+
+func (s *MockAPIServer) KillLiveLesson(ctx context.Context, uuid *pb.LessonUUID) (*pb.KillLiveLessonStatus, error) {
+	return &pb.KillLiveLessonStatus{Success: true}, nil
+}
+
+func (s *MockAPIServer) RequestVerification(ctx context.Context, uuid *pb.LessonUUID) (*pb.VerificationTaskUUID, error) {
+	return &pb.VerificationTaskUUID{Id: "abcdefdfdf"}, nil
+}
+
+func (s *MockAPIServer) GetVerification(ctx context.Context, vtUUID *pb.VerificationTaskUUID) (*pb.VerificationTask, error) {
+	return &pb.VerificationTask{}, nil
+}

--- a/cmd/syringed-mock/main.go
+++ b/cmd/syringed-mock/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+
+	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	config "github.com/nre-learning/syringe/config"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	// log.SetFormatter(&log.JSONFormatter{})
+	log.SetLevel(log.DebugLevel)
+}
+
+func main() {
+
+	syringeConfig, err := config.LoadConfigVars()
+	if err != nil {
+		log.Error(err)
+		log.Fatalf("Invalid configuration. Please re-run Syringe with appropriate env variables")
+	}
+
+	// curriculum, err := api.ImportCurriculum(syringeConfig)
+	// if err != nil {
+	// 	log.Warn(err)
+	// }
+
+	apiServer := &MockAPIServer{}
+	err = apiServer.StartAPI(syringeConfig)
+	if err != nil {
+		log.Fatalf("Problem starting API: %s", err)
+	}
+}

--- a/cmd/syringed-mock/main.go
+++ b/cmd/syringed-mock/main.go
@@ -1,35 +1,49 @@
 package main
 
 import (
-
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-
+	pb "github.com/nre-learning/syringe/api/exp/generated"
 	config "github.com/nre-learning/syringe/config"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 func init() {
-	// log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.DebugLevel)
 }
 
 func main() {
 
-	syringeConfig, err := config.LoadConfigVars()
-	if err != nil {
-		log.Error(err)
-		log.Fatalf("Invalid configuration. Please re-run Syringe with appropriate env variables")
+	syringeConfig := &config.SyringeConfig{
+		Domain:   "localhost",
+		GRPCPort: 50099,
+		HTTPPort: 8086,
 	}
 
-	// curriculum, err := api.ImportCurriculum(syringeConfig)
-	// if err != nil {
-	// 	log.Warn(err)
-	// }
+	var lesson *pb.Lesson
+	err := yaml.Unmarshal([]byte(lessonRaw), &lesson)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	apiServer := &MockAPIServer{}
+	var collection *pb.Collection
+	err = yaml.Unmarshal([]byte(collectionRaw), &collection)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	apiServer := &MockAPIServer{
+		Lessons: []*pb.Lesson{
+			lesson,
+		},
+		Collections: []*pb.Collection{
+			collection,
+		},
+	}
 	err = apiServer.StartAPI(syringeConfig)
 	if err != nil {
 		log.Fatalf("Problem starting API: %s", err)
 	}
+
+	ch := make(chan struct{})
+	<-ch
 }

--- a/cmd/syringed-mock/mocks.go
+++ b/cmd/syringed-mock/mocks.go
@@ -33,6 +33,13 @@ endpoints:
     port: 22
     type: ssh
 
+- name: webserver1
+  image: antidotelabs/webserver
+  presentations:
+  - name: web
+    port: 80
+    type: http
+
 stages:
 - id: 0
   description: This is a code smell you really should fix this

--- a/cmd/syringed-mock/mocks.go
+++ b/cmd/syringed-mock/mocks.go
@@ -1,0 +1,41 @@
+package main
+
+const (
+	collectionRaw = `---
+id: 1
+title: Test Collection
+image: https://networkreliability.engineering/images/2019/09/antidotev040.png
+website: https://networkreliability.engineering
+contactEmail: "blah@blah.com"
+briefDescription: Terse is best.
+longDescription: big long description that in no way is fake or made up. No sir.
+type: vendor
+tier: prod`
+
+	lessonRaw = `---
+lessonName: Antidote Test Lesson
+lessonId: 1
+category: fundamentals
+tier: ptr
+description: foobar
+
+slug: foobar
+tags:
+- foo
+- bar
+
+endpoints:
+
+- name: linux
+  image: antidotelabs/utility
+  presentations:
+  - name: cli
+    port: 22
+    type: ssh
+
+stages:
+- id: 0
+  description: This is a code smell you really should fix this
+- id: 1
+  description: Stage 1`
+)

--- a/cmd/syringed-mock/server.go
+++ b/cmd/syringed-mock/server.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	swag "github.com/nre-learning/syringe/api/exp/swagger"
+	config "github.com/nre-learning/syringe/config"
+
+	"github.com/nre-learning/syringe/pkg/ui/data/swagger"
+
+	ghandlers "github.com/gorilla/handlers"
+	runtime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	pb "github.com/nre-learning/syringe/api/exp/generated"
+	assetfs "github.com/philips/go-bindata-assetfs"
+	log "github.com/sirupsen/logrus"
+	grpc "google.golang.org/grpc"
+
+	gw "github.com/nre-learning/syringe/api/exp/generated"
+)
+
+type MockAPIServer struct{}
+
+func (apiServer *MockAPIServer) StartAPI(config *config.SyringeConfig) error {
+
+	grpcPort := config.GRPCPort
+	httpPort := config.HTTPPort
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
+	if err != nil {
+		log.Errorf("failed to listen: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+	pb.RegisterLiveLessonsServiceServer(grpcServer, apiServer)
+	// pb.RegisterCurriculumServiceServer(grpcServer, apiServer)
+	// pb.RegisterCollectionServiceServer(grpcServer, apiServer)
+	pb.RegisterLessonServiceServer(grpcServer, apiServer)
+	// pb.RegisterSyringeInfoServiceServer(grpcServer, apiServer)
+	// pb.RegisterKubeLabServiceServer(grpcServer, apiServer)
+	defer grpcServer.Stop()
+
+	// Start grpc server
+	go grpcServer.Serve(lis)
+
+	// Start REST proxy
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	gwmux := runtime.NewServeMux()
+	opts := []grpc.DialOption{grpc.WithInsecure()}
+
+	// Register GRPC-gateway (HTTP) endpoints
+	err = gw.RegisterLiveLessonsServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
+	if err != nil {
+		return err
+	}
+	err = gw.RegisterLessonServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
+	if err != nil {
+		return err
+	}
+	// err = gw.RegisterSyringeInfoServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
+	// if err != nil {
+	// 	return err
+	// }
+	// err = gw.RegisterCollectionServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
+	// if err != nil {
+	// 	return err
+	// }
+	// err = gw.RegisterCurriculumServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// Handle swagger requests
+	mux := http.NewServeMux()
+	mux.Handle("/", gwmux)
+	mux.HandleFunc("/livelesson.json", func(w http.ResponseWriter, req *http.Request) {
+		io.Copy(w, strings.NewReader(swag.Livelesson))
+	})
+	mux.HandleFunc("/lesson.json", func(w http.ResponseWriter, req *http.Request) {
+		io.Copy(w, strings.NewReader(swag.Lesson))
+	})
+	// mux.HandleFunc("/syringeinfo.json", func(w http.ResponseWriter, req *http.Request) {
+	// 	io.Copy(w, strings.NewReader(swag.Syringeinfo))
+	// })
+	// mux.HandleFunc("/collection.json", func(w http.ResponseWriter, req *http.Request) {
+	// 	io.Copy(w, strings.NewReader(swag.Collection))
+	// })
+	// mux.HandleFunc("/curriculum.json", func(w http.ResponseWriter, req *http.Request) {
+	// 	io.Copy(w, strings.NewReader(swag.Curriculum))
+	// })
+	serveSwagger(mux)
+
+	log.WithFields(log.Fields{
+		"gRPC Port": grpcPort,
+		"HTTP Port": httpPort,
+	}).Info("Syringe API starting...")
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", httpPort),
+		Handler: grpcHandlerFunc(grpcServer, mux),
+	}
+	srv.ListenAndServe()
+	return nil
+}
+
+// grpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
+// connections or otherHandler otherwise. Copied from cockroachdb.
+func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Handler {
+
+	// Add handler for grpc server
+	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO(tamird): point to merged gRPC code rather than a PR.
+		// This is a partial recreation of gRPC's internal checks https://github.com/grpc/grpc-go/pull/514/files#diff-95e9a25b738459a2d3030e1e6fa2a718R61
+		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			otherHandler.ServeHTTP(w, r)
+		}
+	})
+
+	// Allow CORS (ONLY IN PREPROD)
+	// Add gorilla's logging handler for standards-based access logging
+	return ghandlers.LoggingHandler(os.Stdout, allowCORS(handlerFunc))
+}
+
+// allowCORS allows Cross Origin Resoruce Sharing from any origin.
+// Don't do this without consideration in production systems.
+func allowCORS(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if origin := r.Header.Get("Origin"); origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
+				preflightHandler(w, r)
+				return
+			}
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+// preflightHandler adds the necessary headers in order to serve
+// CORS from any origin using the methods "GET", "HEAD", "POST", "PUT", "DELETE"
+// We insist, don't do this without consideration in production systems.
+func preflightHandler(w http.ResponseWriter, r *http.Request) {
+	headers := []string{"Content-Type", "Accept"}
+	w.Header().Set("Access-Control-Allow-Headers", strings.Join(headers, ","))
+	methods := []string{"GET", "HEAD", "POST", "PUT", "DELETE"}
+	w.Header().Set("Access-Control-Allow-Methods", strings.Join(methods, ","))
+	glog.Infof("preflight request for %s", r.URL.Path)
+}
+
+func serveSwagger(mux *http.ServeMux) {
+	mime.AddExtensionType(".svg", "image/svg+xml")
+
+	// Expose files in third_party/swagger-ui/ on <host>/swagger
+	fileServer := http.FileServer(&assetfs.AssetFS{
+		Asset:    swagger.Asset,
+		AssetDir: swagger.AssetDir,
+		Prefix:   "third_party/swagger-ui",
+	})
+	prefix := "/swagger/"
+	mux.Handle(prefix, http.StripPrefix(prefix, fileServer))
+}

--- a/cmd/syringed-mock/server.go
+++ b/cmd/syringed-mock/server.go
@@ -122,6 +122,14 @@ func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Ha
 
 	// Add handler for grpc server
 	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Temporary hack to get HTTP presentations working in antidote-web when working off
+		// of this mocked API. Should figure out a way to specify path as a normal function of the API
+		// rather than have antidote-web determine this on its own. (TODO)
+		if strings.Contains(r.RequestURI, "webserver1") {
+			http.Redirect(w, r, "http://127.0.0.1:8090/", 302)
+		}
+
 		// TODO(tamird): point to merged gRPC code rather than a PR.
 		// This is a partial recreation of gRPC's internal checks https://github.com/grpc/grpc-go/pull/514/files#diff-95e9a25b738459a2d3030e1e6fa2a718R61
 		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {

--- a/cmd/syringed-mock/server.go
+++ b/cmd/syringed-mock/server.go
@@ -26,7 +26,10 @@ import (
 	gw "github.com/nre-learning/syringe/api/exp/generated"
 )
 
-type MockAPIServer struct{}
+type MockAPIServer struct {
+	Lessons     []*pb.Lesson
+	Collections []*pb.Collection
+}
 
 func (apiServer *MockAPIServer) StartAPI(config *config.SyringeConfig) error {
 
@@ -41,7 +44,7 @@ func (apiServer *MockAPIServer) StartAPI(config *config.SyringeConfig) error {
 	grpcServer := grpc.NewServer()
 	pb.RegisterLiveLessonsServiceServer(grpcServer, apiServer)
 	// pb.RegisterCurriculumServiceServer(grpcServer, apiServer)
-	// pb.RegisterCollectionServiceServer(grpcServer, apiServer)
+	pb.RegisterCollectionServiceServer(grpcServer, apiServer)
 	pb.RegisterLessonServiceServer(grpcServer, apiServer)
 	// pb.RegisterSyringeInfoServiceServer(grpcServer, apiServer)
 	// pb.RegisterKubeLabServiceServer(grpcServer, apiServer)
@@ -71,10 +74,10 @@ func (apiServer *MockAPIServer) StartAPI(config *config.SyringeConfig) error {
 	// if err != nil {
 	// 	return err
 	// }
-	// err = gw.RegisterCollectionServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
-	// if err != nil {
-	// 	return err
-	// }
+	err = gw.RegisterCollectionServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
+	if err != nil {
+		return err
+	}
 	// err = gw.RegisterCurriculumServiceHandlerFromEndpoint(ctx, gwmux, fmt.Sprintf(":%d", grpcPort), opts)
 	// if err != nil {
 	// 	return err
@@ -92,9 +95,9 @@ func (apiServer *MockAPIServer) StartAPI(config *config.SyringeConfig) error {
 	// mux.HandleFunc("/syringeinfo.json", func(w http.ResponseWriter, req *http.Request) {
 	// 	io.Copy(w, strings.NewReader(swag.Syringeinfo))
 	// })
-	// mux.HandleFunc("/collection.json", func(w http.ResponseWriter, req *http.Request) {
-	// 	io.Copy(w, strings.NewReader(swag.Collection))
-	// })
+	mux.HandleFunc("/collection.json", func(w http.ResponseWriter, req *http.Request) {
+		io.Copy(w, strings.NewReader(swag.Collection))
+	})
 	// mux.HandleFunc("/curriculum.json", func(w http.ResponseWriter, req *http.Request) {
 	// 	io.Copy(w, strings.NewReader(swag.Curriculum))
 	// })


### PR DESCRIPTION
Currently, in order to do testing or development work on antidote-web, one needs to spin up a "proper" version of Syringe - meaning one that is running inside and integrated with a running Kubernetes cluster, and using real images. Even in selfmedicate, this is way too heavy-handed if all you want is some mock data on which to develop external components.

While this could be done as an external entity - like a Python script that just outputs some JSON - it's also useful to create this mock service as part of Syringe, to take advantages of all of the protobuf message and service definitions. This means that as the API changes, the mock data can change with it, and be versioned alongside the "real" Syringe services.

So, this PR introduces a new Syringe service that runs the bare minimum amount of code needed to spin up a gRPC service with grpc-gateway for REST, and bare-minimum satisfaction of the required services, with totally made-up data. No integration with Kubernetes, no scheduler of any kind, and no state at all. At the moment, it's just statically returning fake data.

> **Important Note** - this is largely a stopgap measure until [MP1](https://github.com/nre-learning/proposals/blob/master/antidote-v1.0/roadmap.md#mp1-syringe-re-architecture) is completed - at which point we'll not only have a separate microservice for the Syringe API, as well as a back-end database we can populate with mock data. This addition to Syringe is not meant to be full-featured - only to provide the absolute basics wrt data that Syringe normally provides, so the front-end can have something to work with. This is why this PR includes YAML files embedded into the code as Go strings - just something very basic to work with for now.