### PR TITLE
Add config option to control imagepullpolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Disable TSDB by default (configurable) [#130](https://github.com/nre-learning/syringe/pull/130)
 - Cleaned up and updated deps - installing grpc tooling from source [#135](https://github.com/nre-learning/syringe/pull/135)
 - Change SYRINGE_DOMAIN to optional variable, and provide default [#142](https://github.com/nre-learning/syringe/pull/142)
+- Add config option to control imagepullpolicy [#145](https://github.com/nre-learning/syringe/pull/145)
 
 ## v0.4.0 - August 07, 2019
 

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,8 @@ type SyringeConfig struct {
 	CurriculumRepoRemote string
 	CurriculumRepoBranch string
 
+	AlwaysPull bool
+
 	PrivilegedImages []string
 
 	AllowEgress bool
@@ -60,9 +62,9 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.CurriculumDir = curriculumDir
 	}
 
-        /*
-                OPTIONAL
-        */
+	/*
+	   OPTIONAL
+	*/
 
 	// +syringeconfig SYRINGE_DOMAIN is used when directing iframe resources to the appropriate place.
 	// Specify the full domain you're using to access the environment.
@@ -186,6 +188,16 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.AllowEgress = false
 	} else {
 		config.AllowEgress = true
+	}
+
+	// +syringeconfig SYRINGE_IMAGE_PULL_POLICY is a boolean variable that controls the ImagePullPolicy of all
+	// pods within a lesson. Defaults to true, which results in an "Always" ImagePullPolicy. Setting to false
+	// will result in an "IfNotPresent" policy.
+	val := os.Getenv("SYRINGE_ALWAYS_PULL")
+	if alwaysPull, err := strconv.ParseBool(val); err == nil {
+		config.AlwaysPull = alwaysPull
+	} else {
+		config.AlwaysPull = true
 	}
 
 	// +syringeconfig SYRINGE_PRIVILEGED_IMAGES is a string slice that specifies which images need privileged

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -67,6 +67,7 @@ func TestConfigJSON(t *testing.T) {
 		CurriculumVersion:    "latest",
 		CurriculumRepoRemote: "https://github.com/nre-learning/nrelabs-curriculum.git",
 		CurriculumRepoBranch: "master",
+		AlwaysPull:           true,
 		PrivilegedImages: []string{
 			"antidotelabs/container-vqfx",
 			"antidotelabs/vqfx-snap1",

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -12,6 +12,7 @@ import (
 	// Kubernetes Types
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -46,6 +47,11 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 		imageRef = ep.GetImage()
 	} else {
 		imageRef = fmt.Sprintf("%s:%s", ep.GetImage(), ls.SyringeConfig.CurriculumVersion)
+	}
+
+	pullPolicy := v1.PullAlways
+	if !ls.SyringeConfig.AlwaysPull {
+		pullPolicy = v1.PullIfNotPresent
 	}
 
 	pod := &corev1.Pod{
@@ -91,7 +97,7 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 				{
 					Name:            ep.GetName(),
 					Image:           imageRef,
-					ImagePullPolicy: "Always",
+					ImagePullPolicy: pullPolicy,
 					Env: []corev1.EnvVar{
 						// Passing in full ref as an env var in case the pod needs to configure a base URL for ingress purposes.
 						{Name: "SYRINGE_FULL_REF", Value: fmt.Sprintf("%s-%s", nsName, ep.GetName())},


### PR DESCRIPTION
When using selfmedicate to develop new curriculum content, it's important to use the `latest` images so you aren't developing against old software. As a result, Syringe uses an ImagePullPolicy of "Always" for all pods to ensure this remains true.

However, [as discussed in our community forums](https://community.networkreliability.engineering/t/curriculum-version-in-selfmedicate/207), this can present some pretty severe challenges, as the latest curriculum images are rebuilt nightly. This means that every day, curriculum contributors must re-download all images (often several GB in size) since the image hash will be different.

This PR introduces a configuration option that, when set to false, instructs kubernetes to only pull if the image doesn't exist. If curriculum authors wish to get the latest images, they'll have to do this manually - but this can be at their discretion, and only when they really need to do it, as opposed to forcibly every day.

If not set, the default value results in the same behavior that's currently in place - an image pull policy of "Always". This still makes the most sense for production, as we should only be using tagged images there anyways, and they almost never change. When they do change, we want to re-pull them immediately, because they likely include fixes that need to be used.