### PR TITLE
Move to DNS-based identifiers for http presentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Change SYRINGE_DOMAIN to optional variable, and provide default [#142](https://github.com/nre-learning/syringe/pull/142)
 - Add config option to control imagepullpolicy [#145](https://github.com/nre-learning/syringe/pull/145)
 - De-couple namespaces from tier - implement syringe ID option [#150](https://github.com/nre-learning/syringe/pull/150)
+- Move to DNS-based identifiers for http presentations [#151](https://github.com/nre-learning/syringe/pull/151)
 
 ## v0.4.0 - August 07, 2019
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ type SyringeConfig struct {
 
 	PrivilegedImages []string
 
+	CertLocation string
+
 	AllowEgress bool
 }
 
@@ -230,6 +232,16 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		}
 	} else {
 		config.PrivilegedImages = strings.Split(privImages, ",")
+	}
+
+	// +syringeconfig SYRINGE_TLS_CERT_LOCATION is the location of the TLS certificate that should be copied into each
+	// namespace by syncSecret. Used primarily to provide HTTPS to http endpoint presentations.
+	// Format is <namespace>/<certname>. Defaults to "prod/tls-cert"
+	certLocation := os.Getenv("SYRINGE_TLS_CERT_LOCATION")
+	if certLocation == "" {
+		config.CertLocation = "tls-certificate"
+	} else {
+		config.CertLocation = certLocation
 	}
 
 	log.Debugf("Syringe config: %s", config.JSON())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -79,7 +79,8 @@ func TestConfigJSON(t *testing.T) {
 			"antidotelabs/cvx",
 			"antidotelabs/frr",
 		},
-		AllowEgress: false,
+		CertLocation: "tls-certificate",
+		AllowEgress:  false,
 	}
 
 	t.Log(syringeConfig.JSON())

--- a/scheduler/kubelab.go
+++ b/scheduler/kubelab.go
@@ -149,7 +149,10 @@ func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, 
 		iframeIngress, _ := ls.createIngress(
 			ns.ObjectMeta.Name,
 			jupyterEp,
-			8888,
+			&pb.Presentation{
+				Name: "web",
+				Port: 8888,
+			},
 		)
 		kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress
 	}
@@ -205,7 +208,7 @@ func (ls *LessonScheduler) createKubeLab(req *LessonScheduleRequest) (*KubeLab, 
 				iframeIngress, _ := ls.createIngress(
 					ns.ObjectMeta.Name,
 					ep,
-					p.Port,
+					p,
 				)
 				kl.Ingresses[iframeIngress.ObjectMeta.Name] = iframeIngress
 			} else if p.Type == "vnc" {

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -98,10 +98,6 @@ func (ls *LessonScheduler) createPod(ep *pb.Endpoint, networks []string, req *Le
 					Name:            ep.GetName(),
 					Image:           imageRef,
 					ImagePullPolicy: pullPolicy,
-					Env: []corev1.EnvVar{
-						// Passing in full ref as an env var in case the pod needs to configure a base URL for ingress purposes.
-						{Name: "SYRINGE_FULL_REF", Value: fmt.Sprintf("%s-%s", nsName, ep.GetName())},
-					},
 
 					Ports:        []corev1.ContainerPort{}, // Will set below
 					VolumeMounts: volumeMounts,


### PR DESCRIPTION
Changes the way ingresses for HTTP presentations are defined. No longer routing based on path, which has presented problems for web apps that assume they're operating on webroot. Rather, we're now giving each HTTP presentation its own subdomain.

This does NOT mean that Syringe is now interacting with DNS services in any way. The assumption is that the configured subdomain has a wildcard entry forwarding traffic for all subdomains to the cluster, allowing the ingress controller to simply make routing decisions using this information.

Related to (and merging together with):
- https://github.com/nre-learning/antidote-ui-components/pull/12
- https://github.com/nre-learning/antidote-images/pull/2

## TODO

- [x] Can we clean up SYRINGE_FULL_REF or is that needed by anything else at this point?
- [x] Tests

Closes #149 