### PR TITLE
Move away from a runtime git clone model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Move away from runtime git clone model [#153](https://github.com/nre-learning/syringe/pull/153)
 
 ## v0.5.0 - February 01, 2020
 

--- a/cmd/syringed/main.go
+++ b/cmd/syringed/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
 	"sync"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
@@ -94,13 +92,9 @@ func main() {
 		}
 	}()
 
-	antidoteSha, err := ioutil.ReadFile(fmt.Sprintf("%s/.git/refs/heads/%s", syringeConfig.CurriculumDir, syringeConfig.CurriculumRepoBranch))
-	if err != nil {
-		log.Error("Encountered problem getting antidote SHA")
-		buildInfo["antidoteSha"] = "null"
-	} else {
-		buildInfo["antidoteSha"] = string(antidoteSha)
-	}
+	// TODO(mierdin): This provides the loaded version of the curriculum via syringeinfo, primarily
+	// for the PTR banner on the front-end. Should rename to something that makes sense
+	buildInfo["antidoteSha"] = syringeConfig.CurriculumVersion
 
 	// Start API, and feed it pointer to lesson scheduler so they can talk
 	apiServer := &api.SyringeAPIServer{

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,9 @@ import (
 type SyringeConfig struct {
 	SyringeID string
 
-	CurriculumDir       string
+	CurriculumDir     string
+	CurriculumVersion string
+
 	Tier                string
 	Domain              string
 	GRPCPort            int
@@ -29,11 +31,6 @@ type SyringeConfig struct {
 	InfluxPassword  string
 
 	TSDBExportInterval int
-
-	CurriculumLocal      bool
-	CurriculumVersion    string
-	CurriculumRepoRemote string
-	CurriculumRepoBranch string
 
 	AlwaysPull bool
 

--- a/config/config.go
+++ b/config/config.go
@@ -118,15 +118,6 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		}
 	}
 
-	// +syringeconfig SYRINGE_CURRICULUM_LOCAL is a boolean variable to specify if the curriculum should
-	// be pulled from the local filesystem (true), bypassing the need to clone a repository.
-	curriculumLocal, err := strconv.ParseBool(os.Getenv("SYRINGE_CURRICULUM_LOCAL"))
-	if curriculumLocal == false || err != nil {
-		config.CurriculumLocal = false
-	} else {
-		config.CurriculumLocal = true
-	}
-
 	// +syringeconfig SYRINGE_CURRICULUM_VERSION is the version of the curriculum to use.
 	version := os.Getenv("SYRINGE_CURRICULUM_VERSION")
 	if version == "" {
@@ -134,22 +125,6 @@ func LoadConfigVars() (*SyringeConfig, error) {
 		config.CurriculumVersion = "latest"
 	} else {
 		config.CurriculumVersion = version
-	}
-
-	// +syringeconfig SYRINGE_CURRICULUM_REPO_REMOTE is the git repo from which pull lesson content
-	remote := os.Getenv("SYRINGE_CURRICULUM_REPO_REMOTE")
-	if remote == "" {
-		config.CurriculumRepoRemote = "https://github.com/nre-learning/nrelabs-curriculum.git"
-	} else {
-		config.CurriculumRepoRemote = remote
-	}
-
-	// +syringeconfig SYRINGE_CURRICULUM_REPO_BRANCH is the branch of the git repo where lesson content is located
-	branch := os.Getenv("SYRINGE_CURRICULUM_REPO_BRANCH")
-	if branch == "" {
-		config.CurriculumRepoBranch = "master"
-	} else {
-		config.CurriculumRepoBranch = branch
 	}
 
 	// +syringeconfig SYRINGE_LIVELESSON_TTL is the length of time (in minutes) a lesson is allowed

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,7 +41,7 @@ func equals(tb testing.TB, exp, act interface{}) {
 
 // TestConfigJSON ensures a given config renders correctly as JSON
 func TestConfigJSON(t *testing.T) {
-	os.Setenv("SYRINGE_CURRICULUM", "foo")
+	os.Setenv("SYRINGE_CURRICULUM", "/nrelabs-curriculum")
 	os.Setenv("SYRINGE_ID", "syringe-testing")
 	os.Setenv("SYRINGE_DOMAIN", "bar")
 	syringeConfig, err := LoadConfigVars()
@@ -50,26 +50,23 @@ func TestConfigJSON(t *testing.T) {
 	}
 
 	desired := SyringeConfig{
-		CurriculumDir:        "foo",
-		SyringeID:            "syringe-testing",
-		Tier:                 "local",
-		Domain:               "bar",
-		GRPCPort:             50099,
-		HTTPPort:             8086,
-		DeviceGCAge:          0,
-		NonDeviceGCAge:       0,
-		HealthCheckInterval:  0,
-		LiveLessonTTL:        30,
-		InfluxdbEnabled:      false,
-		InfluxURL:            "https://influxdb.networkreliability.engineering/",
-		InfluxUsername:       "admin",
-		InfluxPassword:       "zerocool",
-		TSDBExportInterval:   0,
-		CurriculumLocal:      false,
-		CurriculumVersion:    "latest",
-		CurriculumRepoRemote: "https://github.com/nre-learning/nrelabs-curriculum.git",
-		CurriculumRepoBranch: "master",
-		AlwaysPull:           true,
+		CurriculumDir:       "/nrelabs-curriculum",
+		SyringeID:           "syringe-testing",
+		Tier:                "local",
+		Domain:              "bar",
+		GRPCPort:            50099,
+		HTTPPort:            8086,
+		DeviceGCAge:         0,
+		NonDeviceGCAge:      0,
+		HealthCheckInterval: 0,
+		LiveLessonTTL:       30,
+		InfluxdbEnabled:     false,
+		InfluxURL:           "https://influxdb.networkreliability.engineering/",
+		InfluxUsername:      "admin",
+		InfluxPassword:      "zerocool",
+		TSDBExportInterval:  0,
+		CurriculumVersion:   "latest",
+		AlwaysPull:          true,
 		PrivilegedImages: []string{
 			"antidotelabs/container-vqfx",
 			"antidotelabs/vqfx-snap1",

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -272,7 +273,7 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 		Name:      "local-copy",
 		ReadOnly:  false,
 		MountPath: "/antidote",
-		SubPath:   strings.TrimPrefix(lesson.LessonDir, "/antidote/"),
+		SubPath:   strings.TrimPrefix(lesson.LessonDir, fmt.Sprintf("%s/", path.Clean(ls.SyringeConfig.CurriculumDir))),
 	})
 
 	return volumes, volumeMounts, initContainers

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -226,94 +226,59 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 
 	lessonDir := strings.TrimPrefix(lesson.LessonDir, fmt.Sprintf("%s/", ls.SyringeConfig.CurriculumDir))
 
-	if ls.SyringeConfig.CurriculumLocal {
-
-		// Init container will mount the host directory as read-only, and copy entire contents into an emptyDir volume
-		initContainers = append(initContainers, corev1.Container{
-			Name:  "copy-local-files",
-			Image: "bash",
-			Command: []string{
-				"bash",
-			},
-			Args: []string{
-				"-c",
-				fmt.Sprintf("cp -r %s-ro/lessons/ %s && adduser -D antidote && chown -R antidote:antidote %s",
-					ls.SyringeConfig.CurriculumDir,
-					ls.SyringeConfig.CurriculumDir,
-					ls.SyringeConfig.CurriculumDir),
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "host-volume",
-					ReadOnly:  true,
-					MountPath: fmt.Sprintf("%s-ro", ls.SyringeConfig.CurriculumDir),
-				},
-				{
-					Name:      "local-copy",
-					ReadOnly:  false,
-					MountPath: ls.SyringeConfig.CurriculumDir,
-				},
-			},
-		})
-
-		// Add outer host volume, should be mounted read-only
-		volumes = append(volumes, corev1.Volume{
-			Name: "host-volume",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: ls.SyringeConfig.CurriculumDir,
-				},
-			},
-		})
-
-		// Add inner container volume, should be mounted read-write so we can copy files into it
-		volumes = append(volumes, corev1.Volume{
-			Name: "local-copy",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		})
-
-		// Finally, mount local copy volume as read-write
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "local-copy",
-			ReadOnly:  false,
-			MountPath: ls.SyringeConfig.CurriculumDir,
-			SubPath:   lessonDir,
-		})
-
-	} else {
-		volumes = append(volumes, corev1.Volume{
-			Name: "git-volume",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		})
-
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "git-volume",
-			ReadOnly:  false,
-			MountPath: ls.SyringeConfig.CurriculumDir,
-			SubPath:   lessonDir,
-		})
-
-		initContainers = append(initContainers, corev1.Container{
-			Name:  "git-clone",
-			Image: fmt.Sprintf("antidotelabs/githelper:%s", ls.BuildInfo["imageVersion"]),
-			Args: []string{
-				ls.SyringeConfig.CurriculumRepoRemote,
-				ls.SyringeConfig.CurriculumRepoBranch,
+	// Init container will mount the host directory as read-only, and copy entire contents into an emptyDir volume
+	initContainers = append(initContainers, corev1.Container{
+		Name:  "copy-local-files",
+		Image: "bash",
+		Command: []string{
+			"bash",
+		},
+		Args: []string{
+			"-c",
+			fmt.Sprintf("cp -r %s-ro/lessons/ %s && adduser -D antidote && chown -R antidote:antidote %s",
 				ls.SyringeConfig.CurriculumDir,
+				ls.SyringeConfig.CurriculumDir,
+				ls.SyringeConfig.CurriculumDir),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "host-volume",
+				ReadOnly:  true,
+				MountPath: fmt.Sprintf("%s-ro", ls.SyringeConfig.CurriculumDir),
 			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "git-volume",
-					ReadOnly:  false,
-					MountPath: ls.SyringeConfig.CurriculumDir,
-				},
+			{
+				Name:      "local-copy",
+				ReadOnly:  false,
+				MountPath: ls.SyringeConfig.CurriculumDir,
 			},
-		})
-	}
+		},
+	})
+
+	// Add outer host volume, should be mounted read-only
+	volumes = append(volumes, corev1.Volume{
+		Name: "host-volume",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: ls.SyringeConfig.CurriculumDir,
+			},
+		},
+	})
+
+	// Add inner container volume, should be mounted read-write so we can copy files into it
+	volumes = append(volumes, corev1.Volume{
+		Name: "local-copy",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
+	// Finally, mount local copy volume as read-write
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      "local-copy",
+		ReadOnly:  false,
+		MountPath: ls.SyringeConfig.CurriculumDir,
+		SubPath:   lessonDir,
+	})
 
 	return volumes, volumeMounts, initContainers
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -224,8 +224,6 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 	volumeMounts := []corev1.VolumeMount{}
 	initContainers := []corev1.Container{}
 
-	lessonDir := strings.TrimPrefix(lesson.LessonDir, fmt.Sprintf("%s/", ls.SyringeConfig.CurriculumDir))
-
 	// Init container will mount the host directory as read-only, and copy entire contents into an emptyDir volume
 	initContainers = append(initContainers, corev1.Container{
 		Name:  "copy-local-files",
@@ -235,21 +233,18 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 		},
 		Args: []string{
 			"-c",
-			fmt.Sprintf("cp -r %s-ro/lessons/ %s && adduser -D antidote && chown -R antidote:antidote %s",
-				ls.SyringeConfig.CurriculumDir,
-				ls.SyringeConfig.CurriculumDir,
-				ls.SyringeConfig.CurriculumDir),
+			"cp -r /antidote-ro/lessons/ /antidote && adduser -D antidote && chown -R antidote:antidote /antidote",
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "host-volume",
 				ReadOnly:  true,
-				MountPath: fmt.Sprintf("%s-ro", ls.SyringeConfig.CurriculumDir),
+				MountPath: "/antidote-ro",
 			},
 			{
 				Name:      "local-copy",
 				ReadOnly:  false,
-				MountPath: ls.SyringeConfig.CurriculumDir,
+				MountPath: "/antidote",
 			},
 		},
 	})
@@ -276,8 +271,8 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "local-copy",
 		ReadOnly:  false,
-		MountPath: ls.SyringeConfig.CurriculumDir,
-		SubPath:   lessonDir,
+		MountPath: "/antidote",
+		SubPath:   strings.TrimPrefix(lesson.LessonDir, "/antidote"),
 	})
 
 	return volumes, volumeMounts, initContainers

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -272,7 +272,7 @@ func (ls *LessonScheduler) getVolumesConfiguration(lesson *pb.Lesson) ([]corev1.
 		Name:      "local-copy",
 		ReadOnly:  false,
 		MountPath: "/antidote",
-		SubPath:   strings.TrimPrefix(lesson.LessonDir, "/antidote"),
+		SubPath:   strings.TrimPrefix(lesson.LessonDir, "/antidote/"),
 	})
 
 	return volumes, volumeMounts, initContainers


### PR DESCRIPTION
As mentioned in #152, it's long past time we move away from a model where each pod results in its own git clone operation. A useful tool in the early days of the project, but now creates a ton of complexity and lesson spin-up time problems.

Syringe has long supported the use of local directories for things like curriculum development in selfmedicate. So, this PR in short makes this the only option. We can remove a lot of unnecessary configuration and conditional logic because of this as well.

Closes https://github.com/nre-learning/syringe/issues/152